### PR TITLE
feat(telegram-plugin): drop lanes, enforce stream_reply(done=true) in checklist mode

### DIFF
--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -924,7 +924,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'stream_reply',
       description:
-        'Send or update a streaming reply that edits one message in-place rather than sending many. Call repeatedly during long tasks with full snapshots of your current message; the plugin throttles edits to ~1/sec to respect Telegram\'s rate limit. Set done=true on your final call to lock the message. The first call sends a fresh message; subsequent calls edit it. Use this instead of `reply` when you want to show progressive updates ("reading file..." → "found it, now searching..." → "here\'s the answer") without spamming the chat. Hard-stops at 4096 chars — longer text throws; fall back to `reply`, which chunks. NOTE: when the agent is configured with stream_mode=checklist (default), an event-driven progress card owns the mid-turn surface on the `progress` lane. In that mode, default-lane (unnamed) calls with done=false are silently suppressed — only your final done=true call posts as the answer. Use lane:"thinking" (or any named lane) if you need a parallel mid-turn surface, or set stream_mode=pty to get the legacy behavior.',
+        'Post the final answer for this turn. The plugin renders an event-driven progress card (Plan → Run → Done with live tool bullets, elapsed time, and status emoji) for free while the turn is in-flight, so you do not need to narrate intermediate progress. Call `stream_reply` exactly once per turn with done=true and the complete answer text. Hard-stops at 4096 chars — longer text throws; fall back to `reply`, which chunks. Calling with done=false is an error in this environment (the progress card already owns the mid-turn surface).',
       inputSchema: {
         type: 'object',
         properties: {
@@ -932,7 +932,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           text: { type: 'string', description: 'Full text snapshot. NOT a delta — pass the complete current content each call.' },
           done: {
             type: 'boolean',
-            description: 'True if this is the final update. After done=true the stream is locked and further calls are no-ops. Default false.',
+            description: 'Must be true. Posts this text as the final answer for the turn and locks the message.',
           },
           message_thread_id: {
             type: 'string',
@@ -942,10 +942,6 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: 'string',
             enum: ['html', 'markdownv2', 'text'],
             description: "Rendering mode. 'html' (default) converts markdown to Telegram HTML.",
-          },
-          lane: {
-            type: 'string',
-            description: "Optional lane name. Each lane gets its own Telegram message per chat+thread. Use for surfacing 'thinking' alongside the main answer stream — e.g. lane: 'thinking' for reasoning progress. Omit for the default answer lane.",
           },
         },
         required: ['chat_id', 'text'],
@@ -1383,7 +1379,6 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
             done: Boolean(args.done),
             message_thread_id: args.message_thread_id as string | undefined,
             format: args.format as string | undefined,
-            lane: args.lane as string | undefined,
           },
           { activeDraftStreams, activeDraftParseModes, suppressPtyPreview },
           {

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -166,19 +166,18 @@ export async function handleStreamReply(
   deps.assertAllowedChat(chat_id)
   const threadId = deps.resolveThreadId(chat_id, args.message_thread_id)
 
-  // Suppress intermediate default-lane updates when the progress card is
-  // active. The card owns the mid-turn surface on the `progress` lane; a
-  // parallel default-lane stream would render as a second Telegram
-  // message showing the same "I'm working on X" narrative the card
-  // already conveys. Only the final `done=true` call survives — that's
-  // the answer message, which the card does NOT replace (the card is
-  // historical status, the answer is the content).
+  // In checklist mode the progress card is the mid-turn surface. A
+  // caller-initiated default-lane stream_reply(done=false) creates a
+  // second surface that either duplicates the card's narrative or
+  // races it. We reject it with a clear error so the caller learns
+  // in-context rather than through silent suppression + a missing
+  // message later. Internal callers (the progress-card driver itself)
+  // pass lane:'progress' and are allowed through.
   const isDefaultLane = args.lane == null || args.lane.length === 0
   if (deps.progressCardActive === true && isDefaultLane && !done) {
-    // Claim the PTY-preview slot even when suppressing: the progress
-    // card may not have emitted yet (first call of the turn), and a PTY
-    // partial landing in that window would otherwise leak through as a
-    // raw-TUI draft_send. Keyed WITHOUT lane (PTY uses lane-less keys).
+    // Claim the PTY-preview slot so any PTY partial that fires after
+    // this rejected call doesn't leak a raw-TUI draft. The claim is
+    // keyed lane-less because the PTY handler uses lane-less keys.
     state.suppressPtyPreview?.add(streamKey(chat_id, threadId))
     deps.logStreamingEvent({
       kind: 'stream_reply_called',
@@ -189,7 +188,12 @@ export async function handleStreamReply(
         streamKey(chat_id, threadId, args.lane),
       ),
     })
-    return { messageId: null, status: 'updated' }
+    throw new Error(
+      'stream_reply(done=false) is not supported in checklist mode. ' +
+        'The progress card already renders mid-turn status (Plan → Run → Done ' +
+        'with live tool bullets). Call stream_reply exactly once per turn ' +
+        'with done=true and your complete final answer.',
+    )
   }
 
   let parseMode: 'HTML' | 'MarkdownV2' | undefined

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -584,24 +584,28 @@ describe('handleStreamReply', () => {
     expect(streamReplyCalledEvents[1].streamExisted).toBe(true)
   })
 
-  describe('progressCardActive suppression', () => {
-    // Pins the duplicate-message bug: with progress-card in checklist mode,
-    // the card emits on lane='progress' and the model's stream_reply with
-    // no lane emits on the default lane — two Telegram messages for one
-    // turn. With progressCardActive=true, intermediate default-lane calls
-    // are suppressed so the card owns mid-turn display; only the final
-    // done=true call posts (the answer).
-    it('suppresses default-lane intermediate calls when progress card is active', async () => {
-      const state = makeState()
+  describe('progressCardActive enforcement', () => {
+    // In checklist mode the progress-card driver owns the mid-turn
+    // surface. A default-lane stream_reply(done=false) is rejected with
+    // an error so the caller (the model) learns in-context to only call
+    // stream_reply with done=true. Previously this was silently
+    // suppressed — the loud error makes the contract deterministic.
+    it('rejects default-lane done=false with a clear error when progress card is active', async () => {
+      const state: StreamReplyState = {
+        ...makeState(),
+        suppressPtyPreview: new Set<string>(),
+      }
       const deps = makeDeps(bot, { progressCardActive: true })
 
-      const pending = handleStreamReply({ chat_id: '1', text: 'working...' }, state, deps)
-      await microtaskFlush()
-      const result = await pending
+      await expect(
+        handleStreamReply({ chat_id: '1', text: 'working...' }, state, deps),
+      ).rejects.toThrow(/stream_reply\(done=false\) is not supported in checklist mode/)
 
       expect(bot.api.sendMessage).not.toHaveBeenCalled()
       expect(state.activeDraftStreams.size).toBe(0)
-      expect(result).toEqual({ messageId: null, status: 'updated' })
+      // PTY-preview slot still claimed so a late PTY partial doesn't
+      // leak a raw-TUI draft_send after the rejection.
+      expect(state.suppressPtyPreview?.has('1:_')).toBe(true)
     })
 
     it('still posts final done=true call when progress card is active', async () => {
@@ -622,7 +626,7 @@ describe('handleStreamReply', () => {
       expect(result.messageId).toBe(500)
     })
 
-    it('does NOT suppress named-lane calls (progress card uses lane=progress itself)', async () => {
+    it('does NOT reject named-lane calls (internal progress-card driver uses lane=progress)', async () => {
       const state = makeState()
       const deps = makeDeps(bot, { progressCardActive: true })
 

--- a/telegram-plugin/tests/streaming-e2e.test.ts
+++ b/telegram-plugin/tests/streaming-e2e.test.ts
@@ -33,6 +33,7 @@ interface Fixture {
     chat_id: string
     text: string
     done?: boolean
+    lane?: string
   }) => Promise<{ messageId: number | null; status: string }>
   /**
    * Fire-and-forget variant: starts handleStreamReply but doesn't await it.
@@ -43,11 +44,12 @@ interface Fixture {
     chat_id: string
     text: string
     done?: boolean
+    lane?: string
   }) => Promise<{ messageId: number | null; status: string }>
   turnEnd: () => void
 }
 
-function setup(): Fixture {
+function setup(opts: { progressCardActive?: boolean } = {}): Fixture {
   const bot = createMockBot()
   const map = new Map<string, DraftStreamHandle>()
   const suppress = new Set<string>()
@@ -61,14 +63,26 @@ function setup(): Fixture {
     suppressPtyPreview: suppress,
     lastPtyPreviewByChat: lastPreview,
   }
-  const srState: StreamReplyState = { activeDraftStreams: map }
+  // Wire suppressPtyPreview into srState only when checklist mode is
+  // active. Legacy PTY-tail tests ("PTY partial after stream_reply
+  // started feeds into the same stream") rely on the slot staying
+  // empty; in checklist mode stream_reply claims it first and PTY
+  // short-circuits to 'suppressed'. Keep the two worlds separate.
+  const srState: StreamReplyState = opts.progressCardActive === true
+    ? { activeDraftStreams: map, suppressPtyPreview: suppress }
+    : { activeDraftStreams: map }
 
   const pty = createPtyPartialHandler(ptyState, {
     bot,
     renderText: (t) => `<i>${t}</i>`, // PTY preview: italic
   })
 
-  const callStreamReply = (args: { chat_id: string; text: string; done?: boolean }) =>
+  const callStreamReply = (args: {
+    chat_id: string
+    text: string
+    done?: boolean
+    lane?: string
+  }) =>
     handleStreamReply(args, srState, {
       bot,
       markdownToHtml: (t) => `<b>${t}</b>`, // stream_reply: bold
@@ -85,6 +99,7 @@ function setup(): Fixture {
       recordOutbound: () => {},
       writeError: () => {},
       throttleMs: 600,
+      progressCardActive: opts.progressCardActive === true,
     })
 
   const turnEnd = () => {
@@ -239,6 +254,107 @@ describe('streaming e2e smoke', () => {
 
     expect(f.map.has('A:_')).toBe(false)
     expect(f.map.has('B:_')).toBe(true)
+  })
+
+  // --- checklist-mode contract ----------------------------------------
+  //
+  // In checklist mode the progress-card driver owns the mid-turn surface.
+  // The model-facing stream_reply tool must:
+  //   - reject any call with done=false (throws, surfaces to the model as
+  //     an MCP tool error so it learns in-context not to call it)
+  //   - accept done=true and post the answer as a single message
+  //
+  // Internal callers (the progress-card driver) pass lane:'progress' and
+  // bypass the rejection. End-to-end shape exercised here mirrors
+  // production when CLERK_TG_STREAM_MODE=checklist (the default).
+
+  it('checklist mode: done=false (default lane) throws a clear tool error', async () => {
+    holder.current = setup({ progressCardActive: true })
+    const f = holder.current
+
+    await expect(
+      f.fireStreamReply({ chat_id: '42', text: 'looking into this…' }),
+    ).rejects.toThrow(/stream_reply\(done=false\) is not supported in checklist mode/)
+
+    expect(f.bot.api.sendMessage).not.toHaveBeenCalled()
+    expect(f.bot.api.editMessageText).not.toHaveBeenCalled()
+    // PTY slot is still claimed — stops a late PTY partial from leaking
+    // a raw-TUI draft after the rejection.
+    expect(f.suppress.has('42:_')).toBe(true)
+  })
+
+  it('checklist mode: done=true posts the answer as one message', async () => {
+    holder.current = setup({ progressCardActive: true })
+    const f = holder.current
+
+    const pdone = f.fireStreamReply({ chat_id: '1', text: 'THE ANSWER', done: true })
+    await microtaskFlush()
+    const r = await pdone
+
+    expect(r.status).toBe('finalized')
+    expect(f.bot.api.sendMessage).toHaveBeenCalledTimes(1)
+    expect(f.bot.api.sendMessage.mock.calls[0][0]).toBe('1')
+    expect(f.bot.api.sendMessage.mock.calls[0][1]).toBe('<b>THE ANSWER</b>')
+    expect(f.map.has('1:_')).toBe(false)
+  })
+
+  it('checklist mode: rejection does NOT block a subsequent done=true answer', async () => {
+    holder.current = setup({ progressCardActive: true })
+    const f = holder.current
+
+    await expect(
+      f.fireStreamReply({ chat_id: '1', text: 'wrong call' }),
+    ).rejects.toThrow()
+
+    vi.advanceTimersByTime(1000)
+    await microtaskFlush()
+    const pdone = f.fireStreamReply({ chat_id: '1', text: 'right answer', done: true })
+    await microtaskFlush()
+    await pdone
+
+    expect(f.bot.api.sendMessage).toHaveBeenCalledTimes(1)
+    expect(f.bot.api.sendMessage.mock.calls[0][1]).toBe('<b>right answer</b>')
+  })
+
+  it('checklist mode: internal lane=progress callers bypass the rejection', async () => {
+    // Progress-card driver path: emits card edits via lane:'progress'.
+    // The lane parameter is stripped from the MCP tool schema so models
+    // can't use it — this exercises the in-process internal code path.
+    holder.current = setup({ progressCardActive: true })
+    const f = holder.current
+
+    const p = f.fireStreamReply({
+      chat_id: '1',
+      text: 'Plan → Run → Done',
+      lane: 'progress',
+    })
+    await microtaskFlush()
+    const r = await p
+
+    expect(r.status).toBe('updated')
+    expect(f.bot.api.sendMessage).toHaveBeenCalledTimes(1)
+    expect(f.bot.api.sendMessage.mock.calls[0][1]).toBe('<b>Plan → Run → Done</b>')
+    expect(f.map.has('1:_:progress')).toBe(true)
+  })
+
+  it('non-checklist mode: done=false still works (pty-mode regression check)', async () => {
+    holder.current = setup({ progressCardActive: false })
+    const f = holder.current
+
+    const p1 = f.fireStreamReply({ chat_id: '1', text: 'chunk 1' })
+    await microtaskFlush()
+    await p1
+
+    expect(f.bot.api.sendMessage).toHaveBeenCalledTimes(1)
+    expect(f.bot.api.sendMessage.mock.calls[0][1]).toBe('<b>chunk 1</b>')
+
+    vi.advanceTimersByTime(1000)
+    await microtaskFlush()
+    const p2 = f.fireStreamReply({ chat_id: '1', text: 'chunk 2', done: true })
+    await microtaskFlush()
+    await p2
+
+    expect(f.bot.api.editMessageText).toHaveBeenCalled()
   })
 
   it('done=true with changed text flushes the final edit before clearing', async () => {


### PR DESCRIPTION
## Summary
Makes the checklist-mode streaming contract runtime-enforced instead of prompt-guided.

**Before:** default-lane `stream_reply(done=false)` silently suppressed. Agents wanting live mid-turn text had to remember to pass `lane: "thinking"` per CLAUDE.md guidance — non-deterministic, regularly failed.

**After:**
- `lane` parameter removed from the `stream_reply` MCP tool schema entirely (models can't set it).
- In checklist mode, default-lane `stream_reply(done=false)` throws a clear error ("stream_reply(done=false) is not supported in checklist mode…") that surfaces as an MCP tool error — the model learns in-context without needing prompt rules.
- Internal callers (the progress-card driver) still pass `lane: 'progress'` via the in-process function signature. Only the MCP-exposed schema drops it.
- Progress card UX is **unchanged** — Plan → Run → Done with live tool bullets, elapsed time, status emoji. That's the mid-turn surface; the single `stream_reply(done=true)` call at end-of-turn is the answer.

## Why
User feedback: "I don't want to rely on CLAUDE.md guidance as not deterministic." Moving the contract enforcement from prompt to runtime makes the behavior identical regardless of which agent / which prompt / which model variant.

## Test plan
- [x] New checklist-mode e2e cases in `streaming-e2e.test.ts`:
  - `done=false` default-lane throws the expected error end-to-end
  - `done=true` posts the answer as one message
  - Rejection does NOT block a subsequent `done=true` (no turn-lockout)
  - Internal `lane: 'progress'` callers bypass the rejection
  - `progressCardActive=false` still accepts `done=false` (pty-mode regression check)
- [x] Updated unit assertions in `stream-reply-handler.test.ts` from silent-suppression to `rejects.toThrow`
- [x] `bun run lint` — tsc clean
- [x] `bun vitest run telegram-plugin/tests/` — 462/462 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)