### PR TITLE
Progress card UX fix: distinctive header + synchronous turn-start render

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -82,6 +82,19 @@ interface PerChatState {
 export interface ProgressDriver {
   /** Feed a session-tail event. Fires emit() as the cadence allows. */
   ingest(event: SessionEvent, chatId: string | null, threadId?: string): void
+  /**
+   * Begin a new turn synchronously — called from the inbound-message
+   * handler the instant a user's message clears the gate, BEFORE any
+   * session-tail event arrives. Primes per-chat state and fires an
+   * immediate render of the "⚙️ Working…" skeleton card so the user
+   * sees the card land within ~1s of their message. Subsequent tool_use
+   * / tool_result / turn_end events (from the session JSONL tail) fold
+   * into the same state and continue editing the card in place.
+   *
+   * Safe to call redundantly: a second startTurn for the same chat
+   * before turn_end just re-primes state with the new userRequest.
+   */
+  startTurn(args: { chatId: string; threadId?: string; userText: string }): void
   /** Current state for a chat (for tests / inspection). */
   peek(chatId: string, threadId?: string): ProgressCardState | undefined
 }
@@ -226,6 +239,26 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         chatState!.pendingTimer = null
         flush(chatState!, /*forceDone*/ false)
       }, delay)
+    },
+
+    startTurn({ chatId, threadId, userText }) {
+      // Synthesize an enqueue event and run it through the normal ingest
+      // path. This guarantees we share all the flush/cadence/teardown
+      // semantics with session-tail-driven enqueues (including the
+      // "fire immediately" branch for enqueue events). The rawContent
+      // wrapper matches the shape extractUserText expects.
+      const raw = `<channel source="clerk-telegram" chat_id="${chatId}"${threadId != null ? ` message_thread_id="${threadId}"` : ''}>${userText}</channel>`
+      this.ingest(
+        {
+          kind: 'enqueue',
+          chatId,
+          messageId: null,
+          threadId: threadId ?? null,
+          rawContent: raw,
+        },
+        chatId,
+        threadId,
+      )
     },
 
     peek(chatId, threadId) {

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -230,13 +230,19 @@ export function render(state: ProgressCardState, now: number): string {
 
   const lines: string[] = []
 
-  // Header: user request + elapsed
+  // Header: distinctive status banner so the card never looks like a normal
+  // reply. While in-flight, lead with ⚙️ <b>Working…</b>; on completion swap
+  // to ✅ <b>Done</b>. The elapsed clock lives on the same line so users can
+  // see "is it still moving?" at a glance.
   const elapsed = formatDuration(now - state.turnStartedAt)
+  const headerIcon = state.stage === 'done' ? '✅' : '⚙️'
+  const headerLabel = state.stage === 'done' ? 'Done' : 'Working…'
+  lines.push(`${headerIcon} <b>${headerLabel}</b> · ⏱ ${elapsed}`)
   if (state.userRequest) {
     lines.push(`💬 ${escapeHtml(truncate(state.userRequest, 120))}`)
   }
-  lines.push(`⏱ ${elapsed}`)
-  lines.push('')
+  // Thin visual separator so the bullets below don't blur into the header.
+  lines.push('─ ─ ─')
 
   // Stage indicator
   const stageParts: string[] = [

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -3285,6 +3285,28 @@ async function handleInbound(
     }
   }
 
+  // Prime the progress card synchronously, BEFORE the MCP notification
+  // and before any session-tail event lands. The session JSONL enqueue
+  // event typically arrives 1–3s after the model wakes up; for very
+  // fast turns that finish inside that window, the user would otherwise
+  // see the card materialize at turn-end. Firing startTurn here lands
+  // the "⚙️ Working…" skeleton within ~1s of the inbound message. If a
+  // steering message extended an already-live turn, skip — the existing
+  // card keeps updating for the in-flight turn.
+  if (!isSteering) {
+    try {
+      progressDriver?.startTurn({
+        chatId: chat_id,
+        threadId: messageThreadId != null ? String(messageThreadId) : undefined,
+        userText: effectiveText,
+      })
+    } catch (err) {
+      process.stderr.write(
+        `telegram channel: progress-card startTurn failed: ${(err as Error).message}\n`,
+      )
+    }
+  }
+
   const imagePath = downloadImage ? await downloadImage() : undefined
 
   // Persist to history before notifying Claude. We're past the gate, the

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -67,6 +67,32 @@ describe('progress-card driver', () => {
     expect(emits[0].html).toContain('💬 hi')
   })
 
+  it('startTurn fires an initial "Working…" render BEFORE any tool_use event', () => {
+    // This is the anti-latency fix: the inbound-message handler calls
+    // startTurn synchronously, so the card lands within ~1s of the user's
+    // message even if the session-tail enqueue event is still several
+    // hundred ms away.
+    const { driver, emits } = harness()
+    driver.startTurn({ chatId: 'c1', userText: 'please investigate' })
+    expect(emits).toHaveLength(1)
+    expect(emits[0].chatId).toBe('c1')
+    expect(emits[0].done).toBe(false)
+    // Distinctive Working… banner is present.
+    expect(emits[0].html).toContain('⚙️ <b>Working…</b>')
+    // No tool_use has been fed in yet — there must be no checklist items.
+    expect(emits[0].html).not.toContain('⚡ <b>')
+    // And the echoed user request shows up so the card ties back to the
+    // user's message.
+    expect(emits[0].html).toContain('please investigate')
+  })
+
+  it('startTurn passes threadId through for forum-topic chats', () => {
+    const { driver, emits } = harness()
+    driver.startTurn({ chatId: 'c1', threadId: 't42', userText: 'hi' })
+    expect(emits).toHaveLength(1)
+    expect(emits[0].threadId).toBe('t42')
+  })
+
   it('emits immediately on stage change (plan → run)', () => {
     const { driver, emits } = harness()
     driver.ingest(enqueue('c1'), null)

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -177,6 +177,24 @@ describe('progress-card render', () => {
     expect(out).not.toContain('<b>🔧 Run</b>')
   })
 
+  it('renders a distinctive "Working…" header while in-progress', () => {
+    const s = fold([enqueue('fix tests')])
+    const out = render(s, 5000)
+    // Distinctive banner that no normal reply would ever produce.
+    expect(out).toContain('⚙️ <b>Working…</b>')
+    // Separator between header and bullets — avoids the "one blob" look.
+    expect(out).toContain('─ ─ ─')
+    // While in-progress, no "Done" banner.
+    expect(out).not.toContain('✅ <b>Done</b> ·')
+  })
+
+  it('swaps the header to "Done" when the turn ends', () => {
+    const s = fold([enqueue('fix tests'), { kind: 'turn_end', durationMs: 1000 }])
+    const out = render(s, 5000)
+    expect(out).toContain('✅ <b>Done</b>')
+    expect(out).not.toContain('⚙️ <b>Working…</b>')
+  })
+
   it('renders running item with elapsed time (tool name bolded)', () => {
     const s = fold([enqueue('test'), { kind: 'tool_use', toolName: 'Bash' }])
     // tool_use fired at t=1100, render at t=3200 → 2.1s elapsed for the item


### PR DESCRIPTION
## Symptom

User reported Telegram mid-turn progress updates were "not working." Investigation showed the cards WERE being sent and edited in place correctly — Telegram API accepted them, the plugin logged `draft_send` + multiple `draft_edit` per turn, and the user even sent a screenshot confirming the card was visible. But it felt like nothing was happening during turns.

## Root causes

1. **Visual**: the card led with `💬 <user-request>` + `⏱ MM:SS` — a layout indistinguishable from a normal reply. Users read past it.
2. **Timing**: the first render fired on the session-tail `enqueue` event, which can trail the inbound Telegram message by 1–3s because `session-tail.ts` reads JSONL that only flushes after the SDK round-trip. Fast turns (~2s total) would skip the live-progress window entirely and the user would only see the final `✅ Done` card at turn-end.

## Fix

**`progress-card.ts` — distinctive header.** Lead the card with a bold, obvious banner no normal reply would ever use:
- in-flight: `⚙️ <b>Working…</b> · ⏱ MM:SS`
- done: `✅ <b>Done</b> · ⏱ MM:SS`

Then echo the user's request (`💬 …`), a thin `─ ─ ─` separator, and the existing Plan → Run → Done bullets / tool lines underneath. Bullet/emoji semantics unchanged.

**`progress-card-driver.ts` — synchronous prime.** Add a `startTurn({chatId, threadId, userText})` method that synthesizes an enqueue `SessionEvent` and runs it through the normal `ingest` path. This preserves all cadence / emit / teardown semantics — it's just a shortcut to trigger the "fire immediately on enqueue" branch without waiting for JSONL.

**`server.ts` — call startTurn on inbound.** In `handleInbound()`, immediately after the gate / permission-reply / steering classification, call `progressDriver?.startTurn(...)` so the card lands within ~1s of the user's message. Steering messages (extending an already-live turn) skip the prime so the existing card keeps updating.

No changes to the MCP tool schemas (`reply`, `stream_reply`). No changes to `session-tail.ts` or the checklist-mode gating in `stream-reply-handler.ts`.

## Visual diff

- **Before**: compact two-line header — `💬 the user's message` then a bare `⏱ 00:04` — followed by a blank line and the Plan→Run→Done bullets. Reads as one homogeneous reply; users scroll past.
- **After**: bold `⚙️ Working… · ⏱ 00:04` header on line 1, then `💬 the user's message`, then a thin `─ ─ ─` separator, then the bullets. Clearly a status card, not a reply. On completion the banner swaps to bold `✅ Done · ⏱ 00:04`.

## Test plan

- [x] `npx vitest run` — all 864 tests pass, including new assertions:
  - `progress-card.test.ts`: "renders a distinctive Working… header while in-progress" + "swaps the header to Done when the turn ends"
  - `progress-card-driver.test.ts`: "startTurn fires an initial Working… render BEFORE any tool_use event" + threadId passthrough
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: send a fast message to the bot and verify the `⚙️ Working…` card lands within ~1s and edits in place as tools run, swapping to `✅ Done` at turn-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)