### PR TITLE
fix(vault): preserve multi-line values from non-TTY stdin + add --file flag

### DIFF
--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
 import { createInterface } from "node:readline";
+import { readFileSync } from "node:fs";
 import { loadConfig } from "../config/loader.js";
 import { resolvePath } from "../config/loader.js";
 import {
@@ -70,6 +71,22 @@ function promptLine(prompt: string, hidden = false): Promise<string> {
   });
 }
 
+/**
+ * Read all bytes from stdin until EOF. Used for piped input so that
+ * multi-line values (JSON, PEM, SSH keys, etc.) are preserved verbatim
+ * instead of being truncated to a single line by readline.
+ */
+function readStdinToEnd(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (chunk: Buffer) => chunks.push(chunk));
+    process.stdin.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    process.stdin.on("error", reject);
+  });
+}
+
 async function getPassphrase(confirm = false): Promise<string> {
   // Check env var first
   const envPassphrase = process.env.CLERK_VAULT_PASSPHRASE;
@@ -120,12 +137,45 @@ export function registerVaultCommand(program: Command): void {
   vault
     .command("set <key>")
     .description("Set a secret in the vault")
-    .action(async (key: string) => {
+    .option(
+      "-f, --file <path>",
+      "Read the secret value from a file (preserves multi-line content)"
+    )
+    .action(async (key: string, opts: { file?: string }) => {
       try {
         const parentOpts = program.opts();
         const vaultPath = getVaultPath(parentOpts.config);
+        // When stdin is piped we need to consume it for the secret value,
+        // so the passphrase must come from the env var rather than a prompt.
+        if (!process.stdin.isTTY && !process.env.CLERK_VAULT_PASSPHRASE && !opts.file) {
+          console.error(
+            chalk.red(
+              "Error: piping a value to `vault set` requires CLERK_VAULT_PASSPHRASE to be set"
+            )
+          );
+          process.exit(1);
+        }
         const passphrase = await getPassphrase();
-        const value = await promptLine("Secret value: ", true);
+
+        let value: string;
+        if (opts.file) {
+          // --file flag: read value from a file verbatim.
+          try {
+            value = readFileSync(resolvePath(opts.file), "utf8");
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error(chalk.red(`Error reading file: ${msg}`));
+            process.exit(1);
+          }
+        } else if (!process.stdin.isTTY) {
+          // Piped/non-TTY stdin: slurp all bytes so multi-line values
+          // (JSON, PEM, SSH keys) are preserved instead of being
+          // truncated to the first line by readline.
+          value = await readStdinToEnd();
+        } else {
+          // Interactive TTY: keep the existing password-masked prompt.
+          value = await promptLine("Secret value: ", true);
+        }
 
         if (!value) {
           console.error(chalk.red("Error: Value cannot be empty"));

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
   createVault,
   openVault,
@@ -137,6 +139,76 @@ describe("vault", () => {
     });
   });
 });
+
+describe("vault set CLI — multi-line values", () => {
+  const binPath = fileURLToPath(new URL("../bin/clerk.ts", import.meta.url));
+  const passphrase = "cli-test-passphrase";
+  let tmpDir: string;
+  let vaultPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "clerk-vault-cli-test-"));
+    vaultPath = join(tmpDir, "vault.enc");
+    createVault(passphrase, vaultPath);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runCli(args: string[], input?: string) {
+    // Pass --config via a throwaway path; we only need `vault set` to run.
+    // The vault path is resolved from the default loader fallback, so we
+    // override it via CLERK_VAULT_PATH-like behavior by writing a minimal
+    // config. Simpler: invoke with --config pointing at a tiny yaml that
+    // sets vault.path.
+    const configPath = join(tmpDir, "clerk.yaml");
+    writeFileSync(
+      configPath,
+      `clerk:\n  version: 1\n  agents_dir: ${tmpDir}/agents\nvault:\n  path: ${vaultPath}\ntelegram:\n  bot_token: x\n  forum_chat_id: "-1"\nagents: {}\n`
+    );
+    return spawnSync(
+      "bun",
+      [binPath, "--config", configPath, "vault", ...args],
+      {
+        input,
+        env: { ...process.env, CLERK_VAULT_PASSPHRASE: passphrase },
+        encoding: "utf8",
+      }
+    );
+  }
+
+  it("preserves multi-line value piped via non-TTY stdin", () => {
+    const multiLine = "line-a\nline-b\nline-c";
+    const result = runCli(["set", "multi"], multiLine);
+    expect(result.status).toBe(0);
+
+    const stored = getSecret(passphrase, vaultPath, "multi");
+    expect(stored).toBe(multiLine);
+  });
+
+  it("preserves a PEM-like value piped via non-TTY stdin", () => {
+    const pem =
+      "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDa\nabc\n-----END PRIVATE KEY-----\n";
+    const result = runCli(["set", "pem"], pem);
+    expect(result.status).toBe(0);
+
+    const stored = getSecret(passphrase, vaultPath, "pem");
+    expect(stored).toBe(pem);
+  });
+
+  it("reads value verbatim from --file flag", () => {
+    const json = '{\n  "key": "value",\n  "nested": {"x": 1}\n}\n';
+    const filePath = join(tmpDir, "secret.json");
+    writeFileSync(filePath, json);
+
+    const result = runCli(["set", "cfg", "--file", filePath]);
+    expect(result.status).toBe(0);
+
+    const stored = getSecret(passphrase, vaultPath, "cfg");
+    expect(stored).toBe(json);
+  });
+}, 30_000);
 
 describe("vault resolver", () => {
   describe("isVaultReference", () => {


### PR DESCRIPTION
## Summary
- `clerk vault set <key>` used readline at `src/cli/vault.ts:128`, which silently truncated multi-line values (JSON, PEM, SSH keys) to the first line when piped. Discovered during Phase 0 vault provisioning and worked around by calling `setSecret()` directly from a bun script.
- Now: when stdin is non-TTY, slurp all bytes to EOF; TTY path keeps the existing masked prompt.
- Also adds `-f, --file <path>` for the "I have a JSON/PEM on disk" case (orthogonal, also small).
- Piping requires `CLERK_VAULT_PASSPHRASE` since stdin is consumed for the value.

## Files touched
- `src/cli/vault.ts` — `readStdinToEnd` helper, non-TTY branch, `--file` flag, explicit passphrase-env guard when piping.
- `tests/vault.test.ts` — 3 new vitest cases spawning the CLI with piped multi-line plain text, a PEM-like blob, and `--file`.

## Test plan
- [x] `npm test` — 874 vitest + 21 bun tests pass
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: `printf 'a\nb\nc' | CLERK_VAULT_PASSPHRASE=… clerk vault set foo` round-trips verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)