### PR TITLE
feat(telegram): quote-reply to latest inbound by default

### DIFF
--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -48,6 +48,7 @@ type SqliteDatabase = {
   prepare(sql: string): {
     run(...params: unknown[]): unknown
     all(...params: unknown[]): unknown[]
+    get(...params: unknown[]): unknown
   }
   transaction(fn: (...args: unknown[]) => unknown): (...args: unknown[]) => unknown
   close(): void
@@ -328,6 +329,42 @@ export function deleteFromHistory(args: DeleteFromHistoryArgs): void {
  * already sent a message during the backstop's delay window, avoiding
  * a duplicate send.
  */
+/**
+ * Look up the most recent inbound (user → bot) message id for a chat, optionally
+ * scoped to a forum-topic thread. Returns `null` if no inbound message exists
+ * yet (fresh chat, or history was disabled when the message arrived).
+ *
+ * Used by the `reply` and `stream_reply` tool handlers to auto-populate
+ * `reply_parameters` so outbound messages quote-thread under whatever the
+ * user last said — the common case for a conversational bot — without the
+ * agent having to pass `reply_to` explicitly every turn.
+ *
+ * `thread_id` filter semantics match `query()`:
+ *   - omitted / undefined → any message in the chat
+ *   - explicit number → only that thread
+ *   - explicit null → only chat-root (non-thread)
+ */
+export function getLatestInboundMessageId(
+  chatId: string,
+  threadId?: number | null,
+): number | null {
+  const params: unknown[] = [chatId]
+  let sql = "SELECT message_id FROM messages WHERE chat_id = ? AND role = 'user'"
+  if (threadId !== undefined) {
+    if (threadId === null) {
+      sql += ' AND thread_id IS NULL'
+    } else {
+      sql += ' AND thread_id = ?'
+      params.push(threadId)
+    }
+  }
+  sql += ' ORDER BY ts DESC, message_id DESC LIMIT 1'
+  const row = requireDb().prepare(sql).get(...params as any[]) as
+    | { message_id: number }
+    | undefined
+  return row?.message_id ?? null
+}
+
 export function getRecentOutboundCount(
   chatId: string,
   withinSeconds: number,

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -60,7 +60,7 @@ import {
   shouldSuppressToolActivity,
   type PtyTailHandle,
 } from './pty-tail.js'
-import { initHistory, recordInbound, recordOutbound, recordEdit, deleteFromHistory, query as queryHistory } from './history.js'
+import { initHistory, recordInbound, recordOutbound, recordEdit, deleteFromHistory, query as queryHistory, getLatestInboundMessageId } from './history.js'
 import {
   parseQueuePrefix,
   formatPriorAssistantPreview,
@@ -835,7 +835,7 @@ const mcp = new Server(
     instructions: [
       'The sender reads Telegram, not this session. Anything you want them to see must go through the reply tool — your transcript output never reaches their chat.',
       '',
-      'Messages from Telegram arrive as <channel source="telegram" chat_id="..." message_id="..." user="..." ts="...">. If the tag has an image_path attribute, Read that file — it is a photo the sender attached. If the tag has attachment_file_id, call download_attachment with that file_id to fetch the file, then Read the returned path. Reply with the reply tool — pass chat_id back. Use reply_to (set to a message_id) only when replying to an earlier message; the latest message doesn\'t need a quote-reply, omit reply_to for normal responses.',
+      'Messages from Telegram arrive as <channel source="telegram" chat_id="..." message_id="..." user="..." ts="...">. If the tag has an image_path attribute, Read that file — it is a photo the sender attached. If the tag has attachment_file_id, call download_attachment with that file_id to fetch the file, then Read the returned path. Reply with the reply tool — pass chat_id back. The reply and stream_reply tools quote-reply to the latest inbound user message by default, so you do NOT need to pass reply_to for normal responses. Pass reply_to (a message_id) only when quoting a specific earlier message, or pass quote:false to send a bare (non-quoted) message.',
       '',
       'reply accepts file paths (files: ["/abs/path.png"]) for attachments. Use react to add emoji reactions, edit_message for interim progress updates, and delete_message when you need to truly remove a message (prefer edit_message if you just want to change text — delete is for retraction). Edits don\'t trigger push notifications — when a long task completes, send a new reply so the user\'s device pings. Use send_typing to show a typing indicator during long operations. Use pin_message to pin important outputs. Use forward_message to quote/resurface earlier messages.',
       '',
@@ -889,7 +889,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'reply',
       description:
-        'Reply on Telegram. Pass chat_id from the inbound message. Optionally pass reply_to (message_id) for threading, message_thread_id for forum topic routing, and files (absolute paths) to attach images or documents.',
+        'Reply on Telegram. Pass chat_id from the inbound message. By default the reply is a quote-reply to the latest inbound user message in this chat+thread — pass quote:false to opt out, or pass an explicit reply_to to thread under a specific earlier message. message_thread_id routes to a forum topic; files (absolute paths) attach images or documents.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -897,7 +897,11 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           text: { type: 'string' },
           reply_to: {
             type: 'string',
-            description: 'Message ID to thread under. Use message_id from the inbound <channel> block.',
+            description: 'Message ID to thread under. Overrides the default (latest inbound).',
+          },
+          quote: {
+            type: 'boolean',
+            description: 'Opt out of the default quote-reply behavior. Default: true (quotes the latest inbound user message). Pass false to send a bare message with no quote reference. Ignored when reply_to is explicitly set.',
           },
           message_thread_id: {
             type: 'string',
@@ -924,7 +928,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'stream_reply',
       description:
-        'Post the final answer for this turn. The plugin renders an event-driven progress card (Plan → Run → Done with live tool bullets, elapsed time, and status emoji) for free while the turn is in-flight, so you do not need to narrate intermediate progress. Call `stream_reply` exactly once per turn with done=true and the complete answer text. Hard-stops at 4096 chars — longer text throws; fall back to `reply`, which chunks. Calling with done=false is an error in this environment (the progress card already owns the mid-turn surface).',
+        'Post the final answer for this turn. The plugin renders an event-driven progress card (Plan → Run → Done with live tool bullets, elapsed time, and status emoji) for free while the turn is in-flight, so you do not need to narrate intermediate progress. Call `stream_reply` exactly once per turn with done=true and the complete answer text. By default the streamed message quote-replies to the latest inbound user message in this chat+thread — pass quote:false to opt out, or reply_to to target a specific message. Hard-stops at 4096 chars — longer text throws; fall back to `reply`, which chunks. Calling with done=false is an error in this environment (the progress card already owns the mid-turn surface).',
       inputSchema: {
         type: 'object',
         properties: {
@@ -942,6 +946,14 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: 'string',
             enum: ['html', 'markdownv2', 'text'],
             description: "Rendering mode. 'html' (default) converts markdown to Telegram HTML.",
+          },
+          reply_to: {
+            type: 'string',
+            description: 'Message ID to quote-reply to. Overrides the default (latest inbound).',
+          },
+          quote: {
+            type: 'boolean',
+            description: 'Opt out of the default quote-reply behavior. Default: true. Ignored when reply_to is explicitly set.',
           },
         },
         required: ['chat_id', 'text'],
@@ -1084,8 +1096,14 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
       case 'reply': {
         const chat_id = args.chat_id as string
         const text = repairEscapedWhitespace(args.text as string)
-        const reply_to = args.reply_to != null ? Number(args.reply_to) : undefined
-        const files = (args.files as string[] | undefined) ?? []
+        // Quote-reply default: if the caller didn't pass reply_to (and didn't
+        // opt out with quote:false), auto-populate reply_to with the most
+        // recent inbound user message in this chat+thread. This shifts the
+        // "quote the user's message" default into the plugin so the agent
+        // doesn't have to remember to pass reply_to every turn. Callers who
+        // want a bare (non-quoted) message pass quote:false.
+        const quoteOptIn = args.quote !== false
+        let reply_to = args.reply_to != null ? Number(args.reply_to) : undefined
         const access = loadAccess()
         const configParseMode = access.parseMode ?? 'html'
         const format = (args.format as string | undefined) ?? configParseMode
@@ -1121,6 +1139,23 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
 
         // Resolve thread ID: explicit arg > auto-captured from inbound
         let threadId = resolveThreadId(chat_id, args.message_thread_id as string | undefined)
+
+        // Quote-reply default (see quoteOptIn above). Only fire when history
+        // is enabled — without the SQLite buffer we have nothing to look up.
+        // We scope the lookup to the resolved thread when one exists so a
+        // forum-topic reply doesn't cross-quote a message from a different
+        // topic in the same chat.
+        if (reply_to == null && quoteOptIn && HISTORY_ENABLED) {
+          try {
+            const latest = getLatestInboundMessageId(chat_id, threadId ?? null)
+            if (latest != null) reply_to = latest
+          } catch (err) {
+            // Best-effort: a history lookup failure must not block sending.
+            process.stderr.write(
+              `telegram channel: quote-reply lookup failed: ${(err as Error).message}\n`,
+            )
+          }
+        }
 
         for (const f of files) {
           assertSendable(f)
@@ -1379,6 +1414,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
             done: Boolean(args.done),
             message_thread_id: args.message_thread_id as string | undefined,
             format: args.format as string | undefined,
+            reply_to: args.reply_to as string | undefined,
+            quote: args.quote as boolean | undefined,
           },
           { activeDraftStreams, activeDraftParseModes, suppressPtyPreview },
           {
@@ -1396,6 +1433,14 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
             endStatusReaction,
             historyEnabled: HISTORY_ENABLED,
             recordOutbound,
+            // Wire the quote-reply default only when history is enabled —
+            // without the SQLite buffer we have nothing to look up. Other
+            // internal callers (progress-card driver, PTY-tail) construct
+            // their own deps without this and keep the legacy non-quoting
+            // behavior, which is what we want for those lanes.
+            ...(HISTORY_ENABLED
+              ? { getLatestInboundMessageId }
+              : {}),
             writeError: (line) => process.stderr.write(line),
             throttleMs: 600,
             progressCardActive: streamMode === 'checklist',

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -40,6 +40,13 @@ export interface StreamSendOpts {
   parse_mode?: 'HTML' | 'MarkdownV2'
   message_thread_id?: number
   link_preview_options?: { is_disabled: boolean }
+  /**
+   * Telegram's reply_parameters, used for quote-replying to an earlier
+   * message. Only meaningful on the initial `sendMessage` — `editMessageText`
+   * cannot add a quote reference to an existing message, so the controller
+   * strips this from edit opts internally.
+   */
+  reply_parameters?: { message_id: number }
 }
 
 export type RetryPolicy = <T>(
@@ -53,6 +60,13 @@ export interface StreamControllerConfig {
   threadId?: number
   parseMode?: 'HTML' | 'MarkdownV2'
   disableLinkPreview?: boolean
+  /**
+   * Optional quote-reply target. When set, the initial send attaches
+   * `reply_parameters: { message_id: replyToMessageId }` so the first
+   * streamed message quote-threads under the referenced message. Edits
+   * don't include it (Telegram rejects reply_parameters on edit).
+   */
+  replyToMessageId?: number
   throttleMs?: number
   /** Pre-send idle debounce. See DraftStreamConfig.idleMs. */
   idleMs?: number
@@ -94,12 +108,22 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     onSend,
     onEdit,
     log,
+    replyToMessageId,
   } = cfg
 
-  const sendOpts: StreamSendOpts = {
+  // Base opts shared by send + edit. The initial send adds reply_parameters
+  // on top (see below); edits must NOT carry reply_parameters — Telegram's
+  // editMessageText rejects it.
+  const baseOpts: StreamSendOpts = {
     ...(parseMode ? { parse_mode: parseMode } : {}),
     ...(threadId != null ? { message_thread_id: threadId } : {}),
     ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
+  }
+  const sendOpts: StreamSendOpts = {
+    ...baseOpts,
+    ...(replyToMessageId != null
+      ? { reply_parameters: { message_id: replyToMessageId } }
+      : {}),
   }
 
   return createDraftStream(
@@ -113,7 +137,7 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     },
     async (id, text) => {
       await retry(
-        () => bot.api.editMessageText(chatId, id, text, sendOpts),
+        () => bot.api.editMessageText(chatId, id, text, baseOpts),
         { threadId, chat_id: chatId },
       )
       onEdit?.(id, text.length)

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -36,6 +36,24 @@ export interface StreamReplyArgs {
    * default (unnamed) lane, which preserves legacy behavior.
    */
   lane?: string
+  /**
+   * Explicit quote-reply target. When set, the initial streamed message
+   * quote-threads under this message_id. Overrides the default auto-quote
+   * behavior and ignores `quote`.
+   */
+  reply_to?: string
+  /**
+   * Opt out of the default quote-reply behavior. The handler's default
+   * (when `reply_to` is unset) is to look up the latest inbound user
+   * message via `getLatestInboundMessageId` and quote-reply to it. Pass
+   * `false` to send a bare (non-quoted) streamed message.
+   *
+   * The default is `undefined` (treated as true) so callers that pre-date
+   * this feature keep working. Only the progress-card / activity-lane
+   * internal callers routinely opt out, since those aren't user-visible
+   * conversation replies.
+   */
+  quote?: boolean
 }
 
 export interface StreamReplyState {
@@ -87,6 +105,14 @@ export interface StreamReplyDeps {
   assertAllowedChat: (chatId: string) => void
   /** Resolves the effective thread id (explicit, last-inbound, or undefined). */
   resolveThreadId: (chatId: string, explicit?: string) => number | undefined
+  /**
+   * Resolves the default quote-reply target: the message_id of the latest
+   * inbound user message in this chat+thread, or null if none (empty
+   * history, or history disabled). Called only when the caller didn't
+   * pass `reply_to` and didn't opt out via `quote:false`. Optional —
+   * omit to disable the auto-quote default (legacy behavior).
+   */
+  getLatestInboundMessageId?: (chatId: string, threadId: number | null) => number | null
   /** Config: disable link previews. Default true. */
   disableLinkPreview: boolean
   /** Config: fallback parse mode when args.format is omitted ('html' | 'markdownv2' | 'text'). */
@@ -277,6 +303,26 @@ export async function handleStreamReply(
   }
 
   if (!stream) {
+    // Resolve the effective quote-reply target. Explicit `reply_to` wins;
+    // otherwise (unless the caller opted out with `quote:false`) fall back
+    // to the latest inbound user message in this chat+thread. Resolved
+    // only on stream creation — subsequent `stream_reply` calls for the
+    // same turn edit the existing message, which Telegram doesn't allow
+    // us to add a quote reference to retroactively.
+    let replyToMessageId: number | undefined
+    if (args.reply_to != null) {
+      replyToMessageId = Number(args.reply_to)
+    } else if (args.quote !== false && deps.getLatestInboundMessageId != null) {
+      try {
+        const latest = deps.getLatestInboundMessageId(chat_id, threadId ?? null)
+        if (latest != null) replyToMessageId = latest
+      } catch (err) {
+        deps.writeError(
+          `telegram channel: stream_reply quote-lookup failed: ${err}\n`,
+        )
+      }
+    }
+
     stream = createStreamController({
       bot: deps.bot,
       chatId: chat_id,
@@ -285,6 +331,7 @@ export async function handleStreamReply(
       disableLinkPreview: deps.disableLinkPreview,
       throttleMs: deps.throttleMs ?? 600,
       retry: deps.retry,
+      ...(replyToMessageId != null ? { replyToMessageId } : {}),
       onSend: (messageId, charCount) =>
         deps.logStreamingEvent({ kind: 'draft_send', chatId: chat_id, messageId, charCount }),
       onEdit: (messageId, charCount) =>

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -9,6 +9,7 @@ import {
   recordEdit,
   query,
   getRecentOutboundCount,
+  getLatestInboundMessageId,
   _resetForTests,
 } from '../history.js'
 
@@ -119,6 +120,55 @@ describe('recordInbound + query', () => {
     recordInbound({ chat_id: '-200', thread_id: null, message_id: 1, user: 'b', user_id: '2', ts: 100, text: 'B' })
     expect(query({ chat_id: '-100' }).map(r => r.text)).toEqual(['A'])
     expect(query({ chat_id: '-200' }).map(r => r.text)).toEqual(['B'])
+  })
+})
+
+describe('getLatestInboundMessageId', () => {
+  beforeEach(() => initHistory(stateDir, 30))
+
+  it('returns null when no inbound messages exist', () => {
+    expect(getLatestInboundMessageId('-100')).toBeNull()
+  })
+
+  it('returns the highest-ts inbound message_id for a chat', () => {
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 1, user: 'a', user_id: '1', ts: 100, text: 'a' })
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 2, user: 'a', user_id: '1', ts: 200, text: 'b' })
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 3, user: 'a', user_id: '1', ts: 150, text: 'c' })
+    // ts=200 wins even though id 3 > id 2 but lower ts.
+    expect(getLatestInboundMessageId('-100')).toBe(2)
+  })
+
+  it('ignores outbound (assistant) messages', () => {
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 1, user: 'a', user_id: '1', ts: 100, text: 'hi' })
+    recordOutbound({
+      chat_id: '-100',
+      thread_id: null,
+      message_ids: [2],
+      texts: ['bot reply'],
+      ts: 200,
+    })
+    // Assistant row has higher ts but must not be returned.
+    expect(getLatestInboundMessageId('-100')).toBe(1)
+  })
+
+  it('scopes by thread when threadId passed', () => {
+    recordInbound({ chat_id: '-100', thread_id: 7, message_id: 10, user: 'a', user_id: '1', ts: 100, text: 'topicA' })
+    recordInbound({ chat_id: '-100', thread_id: 8, message_id: 20, user: 'a', user_id: '1', ts: 200, text: 'topicB' })
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 30, user: 'a', user_id: '1', ts: 300, text: 'root' })
+
+    expect(getLatestInboundMessageId('-100', 7)).toBe(10)
+    expect(getLatestInboundMessageId('-100', 8)).toBe(20)
+    expect(getLatestInboundMessageId('-100', null)).toBe(30)
+    // Omitted thread → any thread (highest ts wins).
+    expect(getLatestInboundMessageId('-100')).toBe(30)
+  })
+
+  it('isolates chats', () => {
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 1, user: 'a', user_id: '1', ts: 100, text: 'a' })
+    recordInbound({ chat_id: '-200', thread_id: null, message_id: 99, user: 'b', user_id: '2', ts: 100, text: 'b' })
+    expect(getLatestInboundMessageId('-100')).toBe(1)
+    expect(getLatestInboundMessageId('-200')).toBe(99)
+    expect(getLatestInboundMessageId('-300')).toBeNull()
   })
 })
 

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -652,4 +652,133 @@ describe('handleStreamReply', () => {
       expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('quote-reply default', () => {
+    it('auto-quotes the latest inbound message when reply_to is omitted', async () => {
+      const state = makeState()
+      const lookup = vi.fn<(chatId: string, threadId: number | null) => number | null>(
+        () => 4242,
+      )
+      const deps = makeDeps(bot, { getLatestInboundMessageId: lookup })
+
+      const pending = handleStreamReply({ chat_id: '1', text: 'hi' }, state, deps)
+      await microtaskFlush()
+      await pending
+
+      expect(lookup).toHaveBeenCalledWith('1', null)
+      expect(bot.api.sendMessage.mock.calls[0][2]?.reply_parameters).toEqual({
+        message_id: 4242,
+      })
+    })
+
+    it('explicit reply_to overrides the auto-quote lookup', async () => {
+      const state = makeState()
+      const lookup = vi.fn<(chatId: string, threadId: number | null) => number | null>(
+        () => 4242,
+      )
+      const deps = makeDeps(bot, { getLatestInboundMessageId: lookup })
+
+      const pending = handleStreamReply(
+        { chat_id: '1', text: 'hi', reply_to: '777' },
+        state,
+        deps,
+      )
+      await microtaskFlush()
+      await pending
+
+      // Lookup is skipped entirely when reply_to is explicit.
+      expect(lookup).not.toHaveBeenCalled()
+      expect(bot.api.sendMessage.mock.calls[0][2]?.reply_parameters).toEqual({
+        message_id: 777,
+      })
+    })
+
+    it('quote:false opts out — no reply_parameters sent', async () => {
+      const state = makeState()
+      const lookup = vi.fn<(chatId: string, threadId: number | null) => number | null>(
+        () => 4242,
+      )
+      const deps = makeDeps(bot, { getLatestInboundMessageId: lookup })
+
+      const pending = handleStreamReply(
+        { chat_id: '1', text: 'hi', quote: false },
+        state,
+        deps,
+      )
+      await microtaskFlush()
+      await pending
+
+      expect(lookup).not.toHaveBeenCalled()
+      expect(bot.api.sendMessage.mock.calls[0][2]?.reply_parameters).toBeUndefined()
+    })
+
+    it('no reply_parameters when history lookup returns null (empty history)', async () => {
+      const state = makeState()
+      const lookup = vi.fn<(chatId: string, threadId: number | null) => number | null>(
+        () => null,
+      )
+      const deps = makeDeps(bot, { getLatestInboundMessageId: lookup })
+
+      const pending = handleStreamReply({ chat_id: '1', text: 'hi' }, state, deps)
+      await microtaskFlush()
+      await pending
+
+      expect(lookup).toHaveBeenCalledTimes(1)
+      expect(bot.api.sendMessage.mock.calls[0][2]?.reply_parameters).toBeUndefined()
+    })
+
+    it('no auto-quote when getLatestInboundMessageId dep is omitted (legacy callers)', async () => {
+      const state = makeState()
+      const deps = makeDeps(bot) // no lookup dep
+
+      const pending = handleStreamReply({ chat_id: '1', text: 'hi' }, state, deps)
+      await microtaskFlush()
+      await pending
+
+      expect(bot.api.sendMessage.mock.calls[0][2]?.reply_parameters).toBeUndefined()
+    })
+
+    it('passes thread id to the lookup', async () => {
+      const state = makeState()
+      const lookup = vi.fn<(chatId: string, threadId: number | null) => number | null>(
+        () => 55,
+      )
+      const deps = makeDeps(bot, { getLatestInboundMessageId: lookup })
+
+      const pending = handleStreamReply(
+        { chat_id: '1', text: 'hi', message_thread_id: '7' },
+        state,
+        deps,
+      )
+      await microtaskFlush()
+      await pending
+
+      expect(lookup).toHaveBeenCalledWith('1', 7)
+    })
+
+    it('edit-path does not include reply_parameters (only initial send)', async () => {
+      const state = makeState()
+      const lookup = vi.fn<(chatId: string, threadId: number | null) => number | null>(
+        () => 4242,
+      )
+      const deps = makeDeps(bot, { getLatestInboundMessageId: lookup })
+
+      // First call → send with reply_parameters.
+      await handleStreamReply({ chat_id: '1', text: 'hi' }, state, deps)
+      await microtaskFlush()
+
+      // Second call on the same stream → edit. editMessageText must NOT
+      // receive reply_parameters (Telegram rejects it on edit).
+      vi.advanceTimersByTime(1000)
+      await handleStreamReply({ chat_id: '1', text: 'hi there' }, state, deps)
+      await microtaskFlush()
+
+      expect(bot.api.sendMessage.mock.calls[0][2]?.reply_parameters).toEqual({
+        message_id: 4242,
+      })
+      expect(bot.api.editMessageText).toHaveBeenCalled()
+      const editOpts = bot.api.editMessageText.mock.calls[0][3]
+      expect((editOpts as { reply_parameters?: unknown })?.reply_parameters).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- `reply` and `stream_reply` now auto-quote the latest inbound user message in the same chat+thread, sourced from the SQLite history buffer. The "quote the user's message" default moves into the plugin so the agent doesn't have to remember `reply_to` each turn.
- New `quote: false` opt-out on both tools; explicit `reply_to` still wins over default + opt-out.
- `edit_message` unaffected (edits can't add a quote reference). Internal PTY-tail / progress-card `stream_reply` callers don't wire the lookup dep, preserving legacy non-quoting behavior for those lanes.
- MCP tool descriptions + the server's top-level instructions string updated to reflect the new default.

## Files touched
- `telegram-plugin/history.ts` — new `getLatestInboundMessageId(chatId, threadId?)` helper.
- `telegram-plugin/server.ts` — `reply` handler auto-resolves reply_to; `stream_reply` case threads new args + lookup dep.
- `telegram-plugin/stream-controller.ts` — `replyToMessageId` config → `reply_parameters` on initial send only; edits strip it.
- `telegram-plugin/stream-reply-handler.ts` — `reply_to` + `quote` args; `getLatestInboundMessageId` dep wired into stream creation.
- Tests: `history.test.ts` +5 cases, `stream-reply-handler.test.ts` +7 cases.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 506 pass (was 494), +12 tests, 0 fail
- [ ] Manual smoke: send `reply` with no `reply_to` → expect Telegram UI shows quote of last inbound
- [ ] Manual smoke: `reply` with `quote: false` → expect bare message
- [ ] Manual smoke: fresh chat with no prior inbound → graceful bare send

## Edge cases / decisions
- Auto-quote only activates when `HISTORY_ENABLED` — without the SQLite buffer there's nothing to look up; degrades to bare send.
- Scoped by resolved `threadId` so forum-topic replies don't cross-quote a different topic's message.
- Lookup failure is logged to stderr and proceeds with a bare send rather than failing the reply.
- `stream_reply` resolves the quote target only on stream *creation* — subsequent updates edit the same message and Telegram rejects `reply_parameters` on `editMessageText`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)