### PR TITLE
fix(telegram-plugin): progress card frozen during sub-agent turns (session-tail cursor, progress lane lifecycle, heartbeat)

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -49,6 +49,18 @@ export interface ProgressDriverConfig {
   /** `setTimeout` override for tests. */
   setTimeout?: (fn: () => void, ms: number) => { ref: unknown }
   clearTimeout?: (ref: unknown) => void
+  /** `setInterval` override for tests (used by the heartbeat). */
+  setInterval?: (fn: () => void, ms: number) => { ref: unknown }
+  clearInterval?: (ref: unknown) => void
+  /**
+   * Heartbeat cadence for the no-events-flowing re-render. When a turn
+   * has settled into a long-running tool call (e.g. a sub-agent that
+   * emits no session-JSONL events for minutes), the elapsed-time counter
+   * in the card header never visibly ticks because no event fires a
+   * re-render. The heartbeat forces a flush every `heartbeatMs` while
+   * any chat has a running turn. Default 5000. Set to 0 to disable.
+   */
+  heartbeatMs?: number
 }
 
 /**
@@ -82,6 +94,8 @@ interface PerChatState {
 export interface ProgressDriver {
   /** Feed a session-tail event. Fires emit() as the cadence allows. */
   ingest(event: SessionEvent, chatId: string | null, threadId?: string): void
+  /** Stop internal timers (heartbeat). Idempotent. */
+  dispose?(): void
   /**
    * Begin a new turn synchronously — called from the inbound-message
    * handler the instant a user's message clears the gate, BEFORE any
@@ -115,8 +129,66 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       const handle = (ref as { ref: ReturnType<typeof setTimeout> }).ref
       clearTimeout(handle)
     })
+  const setI =
+    config.setInterval ??
+    ((fn, ms) => {
+      const h = setInterval(fn, ms)
+      return { ref: h }
+    })
+  const clearI =
+    config.clearInterval ??
+    ((ref) => {
+      const handle = (ref as { ref: ReturnType<typeof setInterval> }).ref
+      clearInterval(handle)
+    })
+  const heartbeatMs = config.heartbeatMs ?? 5000
 
   const chats = new Map<string, PerChatState>()
+  let heartbeatHandle: { ref: unknown } | null = null
+  // Tracks the last elapsed-seconds bucket we emitted for each chat so
+  // the heartbeat can coalesce — if the HTML hasn't changed AND the
+  // header elapsed counter (rounded to the heartbeat cadence) would
+  // still render identically, skip the edit.
+  const lastHeartbeatBucket = new Map<string, number>()
+
+  function startHeartbeatIfNeeded(): void {
+    if (heartbeatMs <= 0) return
+    if (heartbeatHandle != null) return
+    if (chats.size === 0) return
+    heartbeatHandle = setI(() => {
+      // Force a re-render for any chat with an open turn so the header
+      // elapsed time and per-item `(dur)` tick visibly — even when no
+      // session-JSONL events have arrived for a while (common while a
+      // sub-agent is running). Coalesce: only actually emit if either
+      // the rendered HTML changed or the elapsed-time bucket
+      // (rounded to the heartbeat period) advanced.
+      for (const [k, cs] of chats) {
+        if (cs.state.stage === 'done') continue
+        const html = render(cs.state, now())
+        const bucket = Math.floor(now() / heartbeatMs)
+        const prevBucket = lastHeartbeatBucket.get(k)
+        if (html === cs.lastEmittedHtml && bucket === prevBucket) continue
+        lastHeartbeatBucket.set(k, bucket)
+        cs.lastEmittedHtml = html
+        cs.lastEmittedAt = now()
+        config.emit({
+          chatId: cs.chatId,
+          threadId: cs.threadId,
+          html,
+          done: false,
+        })
+      }
+      // If every chat has ended, stop the heartbeat to avoid an
+      // always-on timer.
+      if (chats.size === 0) stopHeartbeat()
+    }, heartbeatMs)
+  }
+
+  function stopHeartbeat(): void {
+    if (heartbeatHandle == null) return
+    clearI(heartbeatHandle)
+    heartbeatHandle = null
+  }
 
   function key(chatId: string, threadId?: string): string {
     return threadId != null ? `${chatId}:${threadId}` : chatId
@@ -182,6 +254,10 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           pendingTimer: null,
         }
         chats.set(k, chatState)
+        // New chat became active — ensure the heartbeat is running so
+        // the elapsed counter visibly ticks even during long stretches
+        // with no session events (e.g. sub-agent work).
+        startHeartbeatIfNeeded()
       }
 
       const prev = chatState.state
@@ -214,6 +290,9 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           }
           // Drop the chat state so a subsequent turn starts clean.
           chats.delete(k)
+          lastHeartbeatBucket.delete(k)
+          // Stop heartbeat when no chats remain active.
+          if (chats.size === 0) stopHeartbeat()
         }
         return
       }
@@ -264,6 +343,16 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     peek(chatId, threadId) {
       const k = key(chatId, threadId)
       return chats.get(k)?.state
+    },
+
+    dispose() {
+      stopHeartbeat()
+      for (const cs of chats.values()) {
+        if (cs.pendingTimer != null) {
+          clearT(cs.pendingTimer)
+          cs.pendingTimer = null
+        }
+      }
     },
   }
 }

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -1945,6 +1945,24 @@ function closeActivityLane(chatId: string, threadId: number | undefined): void {
 }
 
 /**
+ * Finalize the progress-card lane stream at the end of a turn. Without
+ * this, the same Telegram messageId keeps getting edited across turns,
+ * so when a new turn opens with a fresh "Working…" skeleton the user
+ * sees the previous turn's "Done"-state 10-item checklist shrink into
+ * a 0-item new card — a jarring visible flicker. Closing the lane here
+ * drops the entry from activeDraftStreams so the next turn posts a
+ * fresh Telegram message (new messageId) for its progress card.
+ */
+function closeProgressLane(chatId: string, threadId: number | undefined): void {
+  const key = `${chatId}:${threadId ?? '_'}:progress`
+  const stream = activeDraftStreams.get(key)
+  if (stream == null) return
+  activeDraftStreams.delete(key)
+  activeDraftParseModes.delete(key)
+  void stream.finalize().catch(() => { /* already logged */ })
+}
+
+/**
  * Resolve a session event into a status reaction transition on whichever
  * controller is currently active for the in-flight chat. Bookkeeping is
  * minimal: we trust the JSONL ordering (Claude processes turns serially),
@@ -2240,6 +2258,10 @@ function handleSessionEvent(ev: SessionEvent): void {
       // status visible in Telegram (no "done" chip); next turn opens a
       // fresh activity stream on the first tool-call bullet.
       closeActivityLane(chatId, threadId)
+      // Close the progress lane as well so the next turn posts a fresh
+      // progress-card Telegram message instead of re-editing the prior
+      // turn's card (see closeProgressLane for the full rationale).
+      closeProgressLane(chatId, threadId)
       currentSessionChatId = null
       currentSessionThreadId = undefined
       currentTurnReplyCalled = false

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -251,14 +251,28 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
   let stopped = false
   let pendingPartial = '' // last read may end mid-line; stash for next read
 
+  // Per-file cursor + partial bookkeeping. This is the Bug 1 fix: when
+  // Claude Code's Agent/Task tool spawns a sub-agent, that sub-agent
+  // writes its OWN session JSONL which briefly becomes newest-mtime in
+  // the projects dir. Without per-file tracking, `findActiveSessionFile`
+  // flips to the sub-agent JSONL, `attachToFile` seeks to its end, and
+  // when the parent JSONL reclaims newest-mtime we'd seek to ITS end
+  // too — missing every event written while we were attached elsewhere
+  // (critical ones like tool_result and turn_end). Tracking cursors per
+  // file by absolute path lets us pick up exactly where we left off on
+  // re-attach.
+  const fileCursors = new Map<string, { cursor: number; pendingPartial: string }>()
+
   function readNew(): void {
     if (stopped || !currentFile) return
     try {
       const stat = statSync(currentFile)
       if (stat.size < cursor) {
-        // File was truncated/replaced — reset cursor
+        // File was truncated/replaced — reset cursor and clear any
+        // stored per-file state for this path.
         cursor = 0
         pendingPartial = ''
+        if (currentFile != null) fileCursors.delete(currentFile)
       }
       if (stat.size === cursor) return
       const buf = Buffer.alloc(stat.size - cursor)
@@ -291,19 +305,35 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
 
   function attachToFile(file: string): void {
     if (currentFile === file) return
+    // Save state for the file we're switching AWAY from, so that if we
+    // later re-attach (e.g. a sub-agent briefly led on mtime, now the
+    // parent leads again) we resume from exactly where we stopped.
+    if (currentFile != null) {
+      fileCursors.set(currentFile, { cursor, pendingPartial })
+    }
     if (watcher) {
       try { watcher.close() } catch { /* ignore */ }
       watcher = null
     }
     currentFile = file
-    pendingPartial = ''
-    // Seek to the current end so we only see new events, not history
-    try {
-      cursor = statSync(file).size
-    } catch {
-      cursor = 0
+    const prior = fileCursors.get(file)
+    if (prior != null) {
+      // Re-attach: pick up exactly where we left off so we don't skip
+      // events written while we were watching a different file.
+      cursor = prior.cursor
+      pendingPartial = prior.pendingPartial
+      log?.(`session-tail: re-attached to ${file} (cursor=${cursor}, restored)`)
+    } else {
+      // First attach to this file — seek to current end so we only see
+      // new events, not history.
+      pendingPartial = ''
+      try {
+        cursor = statSync(file).size
+      } catch {
+        cursor = 0
+      }
+      log?.(`session-tail: attached to ${file} (cursor=${cursor})`)
     }
-    log?.(`session-tail: attached to ${file} (cursor=${cursor})`)
     try {
       watcher = watch(file, () => readNew())
     } catch (err) {

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -9,9 +9,13 @@ import { createProgressDriver, summariseTurn } from '../progress-card-driver.js'
 import { initialState, reduce } from '../progress-card.js'
 import type { SessionEvent } from '../session-tail.js'
 
-function harness(minIntervalMs = 500, coalesceMs = 400, opts?: { captureSummaries?: boolean }) {
+function harness(
+  minIntervalMs = 500,
+  coalesceMs = 400,
+  opts?: { captureSummaries?: boolean; heartbeatMs?: number },
+) {
   let now = 1000
-  const timers: Array<{ fireAt: number; fn: () => void; ref: number }> = []
+  const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
   let nextRef = 0
   const emits: Array<{ chatId: string; threadId?: string; html: string; done: boolean }> = []
   const summaries: string[] = []
@@ -21,6 +25,7 @@ function harness(minIntervalMs = 500, coalesceMs = 400, opts?: { captureSummarie
     onTurnEnd: opts?.captureSummaries ? (s) => summaries.push(s) : undefined,
     minIntervalMs,
     coalesceMs,
+    heartbeatMs: opts?.heartbeatMs,
     now: () => now,
     setTimeout: (fn, ms) => {
       const ref = nextRef++
@@ -28,6 +33,16 @@ function harness(minIntervalMs = 500, coalesceMs = 400, opts?: { captureSummarie
       return { ref }
     },
     clearTimeout: (handle) => {
+      const target = (handle as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === target)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref, repeat: ms })
+      return { ref }
+    },
+    clearInterval: (handle) => {
       const target = (handle as { ref: number }).ref
       const idx = timers.findIndex((t) => t.ref === target)
       if (idx !== -1) timers.splice(idx, 1)
@@ -41,8 +56,14 @@ function harness(minIntervalMs = 500, coalesceMs = 400, opts?: { captureSummarie
       timers.sort((a, b) => a.fireAt - b.fireAt)
       const next = timers[0]
       if (!next || next.fireAt > now) break
-      timers.shift()
-      next.fn()
+      if (next.repeat != null) {
+        // Intervals: reschedule for the next tick before firing.
+        next.fireAt += next.repeat
+        next.fn()
+      } else {
+        timers.shift()
+        next.fn()
+      }
     }
   }
 
@@ -315,6 +336,52 @@ describe('progress-card checklist rendering', () => {
     // Final checklist still visible.
     expect(final.html).toContain('✅ Read a.ts')
     expect(final.html).toContain('✅ Bash echo hi')
+  })
+})
+
+describe('progress-card driver heartbeat', () => {
+  // Bug 3 regression: once a turn settles into "1 long-running Agent
+  // item", no new session-tail events fire and the driver's
+  // change-only emit logic produces zero further renders — so the
+  // elapsed-time counter in the header never visibly ticks. The
+  // heartbeat forces a re-render every `heartbeatMs` while any chat
+  // has an open turn.
+  it('emits periodic renders while a turn is open even with no events flowing', () => {
+    const { driver, emits, advance } = harness(500, 400, { heartbeatMs: 5000 })
+    driver.ingest(enqueue('c1'), null) // initial render
+    driver.ingest({ kind: 'tool_use', toolName: 'Agent' }, 'c1') // stage change
+    const emitsBefore = emits.length
+
+    // Advance 15s with ZERO events. Heartbeat fires every 5s; whether
+    // each tick actually emits depends on whether the render output
+    // differs (which it does, since the header shows elapsed time and
+    // the running item's (dur) bumps past each second boundary).
+    advance(15_000)
+    const delta = emits.length - emitsBefore
+    // Must see at least one heartbeat-driven render — otherwise the
+    // card is frozen for the full 15s with no events, which is the
+    // exact bug we're fixing.
+    expect(delta).toBeGreaterThanOrEqual(1)
+  })
+
+  it('stops the heartbeat after turn_end (no extra renders once the turn is done)', () => {
+    const { driver, emits, advance } = harness(500, 400, { heartbeatMs: 5000 })
+    driver.ingest(enqueue('c1'), null)
+    driver.ingest({ kind: 'turn_end', durationMs: 100 }, 'c1')
+    const countAfterEnd = emits.length
+
+    // Long idle — heartbeat must be dormant.
+    advance(60_000)
+    expect(emits.length).toBe(countAfterEnd)
+  })
+
+  it('can be disabled by setting heartbeatMs=0', () => {
+    const { driver, emits, advance } = harness(500, 400, { heartbeatMs: 0 })
+    driver.ingest(enqueue('c1'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'Agent' }, 'c1')
+    const countBefore = emits.length
+    advance(30_000)
+    expect(emits.length).toBe(countBefore)
   })
 })
 

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, rmSync, utimesSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
   projectTranscriptLine,
   sanitizeCwdToProjectName,
   getProjectsDirForCwd,
+  startSessionTail,
+  type SessionEvent,
 } from '../session-tail.js'
 
 describe('sanitizeCwdToProjectName', () => {
@@ -216,5 +221,121 @@ describe('projectTranscriptLine', () => {
       chatId: '-1009999999999',
       messageId: '103',
     })
+  })
+})
+
+// ─── Bug 1 regression: per-file cursor state survives re-attachment ────
+//
+// Scenario: Claude Code's Agent/Task tool spawns a sub-agent which
+// writes its own JSONL. The sub-agent's file briefly becomes
+// newest-mtime in the projects dir, so `findActiveSessionFile` picks
+// it and we re-target. Events in the sub-agent file get reported.
+// Later, the parent JSONL mtime leads again (the parent resumes). If
+// we seek to the end of the parent at re-attach time, we miss every
+// event the parent wrote while we were watching the sub-agent (most
+// critically: tool_result and turn_end, which means the progress card
+// never flips items to done and never fires the final "Done" render).
+//
+// The fix: track cursors per absolute file path. On re-attach to a
+// known file, restore the saved cursor; on detach, save the current
+// cursor into the map. These tests exercise that round trip with a
+// real temp directory and real files.
+describe('startSessionTail — re-attach resumes from saved cursor', () => {
+  const tempDirs: string[] = []
+  afterEach(() => {
+    for (const d of tempDirs) {
+      try { rmSync(d, { recursive: true, force: true }) } catch { /* ignore */ }
+    }
+    tempDirs.length = 0
+  })
+
+  function mkProjectsDir(): { claudeHome: string; cwd: string; projectsDir: string } {
+    const base = mkdtempSync(join(tmpdir(), 'session-tail-test-'))
+    tempDirs.push(base)
+    const cwd = join(base, 'agent')
+    const claudeHome = join(base, 'claude-home')
+    const projectsDir = getProjectsDirForCwd(cwd, claudeHome)
+    mkdirSync(projectsDir, { recursive: true })
+    return { claudeHome, cwd, projectsDir }
+  }
+
+  function setMtime(path: string, seconds: number): void {
+    utimesSync(path, seconds, seconds)
+  }
+
+  async function wait(ms: number): Promise<void> {
+    await new Promise((r) => setTimeout(r, ms))
+  }
+
+  const assistantTextLine = (text: string): string =>
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } }) + '\n'
+
+  const turnEndLine = JSON.stringify({ type: 'system', subtype: 'turn_duration', durationMs: 1 }) + '\n'
+
+  it('resumes the parent JSONL from the saved cursor after a sub-agent JSONL briefly leads on mtime', async () => {
+    const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+
+    // Parent and sub-agent JSONL files. We manipulate mtimes directly
+    // so the test is deterministic (newest-mtime wins).
+    const parent = join(projectsDir, 'parent.jsonl')
+    const sub = join(projectsDir, 'sub.jsonl')
+
+    // Parent has some history already. Writing this BEFORE startSessionTail
+    // guarantees the initial attach seeks past it (first attach seeks to
+    // current end — we only ever want NEW events).
+    writeFileSync(parent, assistantTextLine('initial parent'))
+    setMtime(parent, 1_000_000) // older
+
+    const events: SessionEvent[] = []
+    const handle = startSessionTail({
+      cwd,
+      claudeHome,
+      rescanIntervalMs: 50,
+      onEvent: (ev) => { events.push(ev) },
+    })
+
+    try {
+      // Give the initial rescan a chance to attach.
+      await wait(120)
+      expect(events).toHaveLength(0) // nothing new yet
+
+      // Use mtimes rooted at "now" to out-rank any writes the fs does
+      // automatically on append (append bumps mtime to wall-clock).
+      const nowSec = Math.floor(Date.now() / 1000)
+
+      // Sub-agent JSONL appears (empty first, so attach seeks-to-end at
+      // position 0 — no "history" to skip). Only then do we append to
+      // simulate the sub-agent writing incrementally.
+      writeFileSync(sub, '')
+      setMtime(sub, nowSec + 10)
+      // Force parent to be "older" than sub so newest-mtime picks sub.
+      setMtime(parent, nowSec + 5)
+      await wait(150) // let rescan attach to the (newly newest) sub file
+
+      appendFileSync(sub, assistantTextLine('from sub-agent'))
+      // Keep sub freshest for the read.
+      setMtime(sub, nowSec + 11)
+      await wait(150)
+
+      // Parent appends events — these are the ones that would be
+      // SKIPPED if we seek-to-end on re-attach. Then bump parent's
+      // mtime so the next rescan flips back to it.
+      appendFileSync(parent, assistantTextLine('parent event A'))
+      appendFileSync(parent, assistantTextLine('parent event B'))
+      appendFileSync(parent, turnEndLine)
+      setMtime(parent, nowSec + 20)
+      await wait(250)
+
+      // The sub-agent text and all three parent events must be present.
+      const textEvents = events
+        .filter((e) => e.kind === 'text')
+        .map((e) => (e as Extract<SessionEvent, { kind: 'text' }>).text)
+      expect(textEvents).toContain('from sub-agent')
+      expect(textEvents).toContain('parent event A')
+      expect(textEvents).toContain('parent event B')
+      expect(events.some((e) => e.kind === 'turn_end')).toBe(true)
+    } finally {
+      handle.stop()
+    }
   })
 })

--- a/telegram-plugin/tests/streaming-orchestration.test.ts
+++ b/telegram-plugin/tests/streaming-orchestration.test.ts
@@ -680,4 +680,77 @@ describe('PTY activity-lane wiring (onActivity → stream_reply lane="activity")
     expect(lastEdit[1]).toBe(activityId)
     expect(lastEdit[2]).toBe('Reading file: foo.ts')
   })
+
+  // ---- closeProgressLane / turn-boundary coverage --------------------
+  //
+  // Bug 2 regression: on turn_end the server also closes the `progress`
+  // lane (the one the progress-card driver owns). Without this, the
+  // same Telegram messageId is re-edited across turns and the user
+  // sees a visible shrink-flicker when a new turn opens with 0 items
+  // on top of the previous turn's 10-item "Done" state. These tests
+  // model `closeProgressLane(chatId, threadId)` exactly like the
+  // existing closeActivityLane cases above.
+
+  function modelCloseProgressLane(
+    state: StreamReplyState,
+    chatId: string,
+    threadId?: number,
+  ): Promise<void> {
+    const key = `${chatId}:${threadId ?? '_'}:progress`
+    const stream = state.activeDraftStreams.get(key)
+    if (stream == null) return Promise.resolve()
+    state.activeDraftStreams.delete(key)
+    return stream.finalize().catch(() => { /* swallow */ })
+  }
+
+  it('closeProgressLane removes the stream entry and is idempotent', async () => {
+    const state: StreamReplyState = { activeDraftStreams: new Map<string, DraftStreamHandle>() }
+    const deps = makeActivityDeps(bot)
+
+    await handleStreamReply(
+      { chat_id: '1', text: '⚙️ Working…', lane: 'progress', format: 'html' },
+      state, deps,
+    )
+    await microtaskFlush()
+    expect(state.activeDraftStreams.has('1:_:progress')).toBe(true)
+
+    await modelCloseProgressLane(state, '1', undefined)
+    expect(state.activeDraftStreams.has('1:_:progress')).toBe(false)
+
+    // Idempotent.
+    await expect(modelCloseProgressLane(state, '1', undefined)).resolves.toBeUndefined()
+    await expect(modelCloseProgressLane(state, 'never', undefined)).resolves.toBeUndefined()
+  })
+
+  it('next turn after closeProgressLane posts a FRESH progress message (new messageId)', async () => {
+    const state: StreamReplyState = { activeDraftStreams: new Map<string, DraftStreamHandle>() }
+    const deps = makeActivityDeps(bot)
+
+    // Turn 1: progress card lives at some messageId.
+    await handleStreamReply(
+      { chat_id: '1', text: '⚙️ Working… (turn 1)', lane: 'progress', format: 'html' },
+      state, deps,
+    )
+    await microtaskFlush()
+    const firstProgressId = state.activeDraftStreams.get('1:_:progress')!.getMessageId()
+    const sendsBefore = bot.api.sendMessage.mock.calls.length
+
+    // turn_end closes the progress lane.
+    await modelCloseProgressLane(state, '1', undefined)
+    expect(state.activeDraftStreams.has('1:_:progress')).toBe(false)
+
+    // Turn 2: the fresh progress-card open must send a NEW message, not
+    // edit the previous one — this is what prevents the shrink-flicker
+    // described in the bug report.
+    await handleStreamReply(
+      { chat_id: '1', text: '⚙️ Working… (turn 2)', lane: 'progress', format: 'html' },
+      state, deps,
+    )
+    await microtaskFlush()
+
+    expect(state.activeDraftStreams.has('1:_:progress')).toBe(true)
+    const secondProgressId = state.activeDraftStreams.get('1:_:progress')!.getMessageId()
+    expect(secondProgressId).not.toBe(firstProgressId)
+    expect(bot.api.sendMessage.mock.calls.length).toBe(sendsBefore + 1)
+  })
 })


### PR DESCRIPTION
## Summary

Three tightly-coupled bugs made the Telegram progress card appear frozen during turns that spawn sub-agents. Fixing any one alone still leaves a broken UX, so they ship together.

- **Bug 1 (session-tail, severe):** `findActiveSessionFile` picks newest-mtime `.jsonl`. When `Agent/Task` spawns a sub-agent with its own JSONL, the tail flipped to it and `attachToFile` seeked to end. When the parent reclaimed newest-mtime, we seeked to *its* end too, losing every `tool_result`/`turn_end` written in between. Fix: track cursors per file path in a `Map`, restore saved cursor on re-attach.
- **Bug 2 (progress lane lifecycle):** `server.ts` closed the `:activity` lane on `turn_end` but not `:progress`. The progress-card messageId was re-edited across turns, producing a visible shrink-flicker. Fix: `closeProgressLane` mirrors `closeActivityLane`.
- **Bug 3 (render cadence):** the driver only emits on change, so once a turn settled into one long-running Agent item the elapsed counter never ticked. Fix: optional 5s `setInterval` heartbeat; starts when a chat becomes active, stops when none remain; coalesces on html + elapsed-time bucket.

Picked the cursor-map approach over sessionId filtering: it's agnostic to why a rotation happens (sub-agents, `/clear`, compaction) and uses the same state restoration on ANY re-attach path.

Files touched: `session-tail.ts`, `progress-card-driver.ts`, `server.ts`, + three matching test files under `tests/`. No unrelated modules touched.

## Test plan

- [x] `bun test` — 506 pass, 0 fail (494 baseline → 500 after rebase onto `feat/telegram-quote-reply-default`-independent main; +6 new tests)
- [x] `bunx tsc --noEmit` clean
- [x] New tests:
  - `session-tail`: cursor map survives a real sub-agent file rotation (temp dir, real mtime manipulation)
  - `streaming-orchestration`: `closeProgressLane` is idempotent; next turn posts a fresh `messageId` (not editing the closed stream)
  - `progress-card-driver`: heartbeat fires while turn is open, stops after `turn_end`, disabled when `heartbeatMs=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)