### PR TITLE
Multi-agent progress card 2/5: correlation (subagent watcher + reducer)

### DIFF
--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -45,6 +45,14 @@ export interface ChecklistItem {
   readonly startedAt: number
   /** Unix ms when tool_result arrived. Only set on done/failed. */
   readonly finishedAt?: number
+  /**
+   * Multi-agent: for `Agent`/`Task` tool_use items only, the `agentId`
+   * of the correlated sub-agent. Set when `sub_agent_started` lands and
+   * matches this item's prompt text. Renderer (later PR) uses it to
+   * keep the [Main] line in 🤖 (not ✅) until the parent's tool_result
+   * arrives. Null until correlation succeeds.
+   */
+  readonly spawnedAgentId?: string | null
 }
 
 export type Stage = 'plan' | 'run' | 'done'
@@ -201,11 +209,61 @@ export function reduce(
         state: 'running',
         startedAt: now,
       }
+      // Multi-agent: if this is an Agent/Task tool_use, stage a pending
+      // spawn awaiting the matching sub-agent JSONL. Correlation key is
+      // the prompt text (the sub-agent's first user message contains
+      // exactly this string). Reverse-race: if a sub-agent already
+      // landed as orphan with this prompt text, adopt it now.
+      let pendingAgentSpawns = state.pendingAgentSpawns
+      let subAgents = state.subAgents
+      if (
+        (event.toolName === 'Agent' || event.toolName === 'Task') &&
+        event.toolUseId &&
+        event.input
+      ) {
+        const promptText = String(event.input.prompt ?? '')
+        const description = String(event.input.description ?? '') || promptText.slice(0, 50)
+        const subagentType =
+          typeof event.input.subagent_type === 'string'
+            ? (event.input.subagent_type as string)
+            : undefined
+        // Reverse-race adoption: scan orphan sub-agents (parentToolUseId
+        // null) for a prompt-text match and adopt the FIRST matching one.
+        // FIFO disambiguates duplicate-prompt bursts (rare).
+        let adopted = false
+        for (const [agentId, sa] of subAgents) {
+          if (sa.parentToolUseId == null && sa.firstPromptText === promptText) {
+            const next = new Map(subAgents)
+            next.set(agentId, {
+              ...sa,
+              parentToolUseId: event.toolUseId,
+              description,
+              subagentType,
+            })
+            subAgents = next
+            adopted = true
+            break
+          }
+        }
+        if (!adopted) {
+          const nextPending = new Map(pendingAgentSpawns)
+          nextPending.set(event.toolUseId, {
+            parentToolUseId: event.toolUseId,
+            description,
+            subagentType,
+            promptText,
+            startedAt: now,
+          })
+          pendingAgentSpawns = nextPending
+        }
+      }
       return {
         ...state,
         items: [...state.items, nextItem],
         stage: 'run',
         thinking: false,
+        pendingAgentSpawns,
+        subAgents,
       }
     }
 
@@ -231,7 +289,128 @@ export function reduce(
       const items = state.items.slice()
       const nextState: ItemState = event.isError === true ? 'failed' : 'done'
       items[idx] = { ...items[idx], state: nextState, finishedAt: now }
-      return { ...state, items }
+      // Multi-agent: a parent Agent/Task tool_result is the authoritative
+      // close-out for its sub-agent. Find any sub-agent linked to this
+      // toolUseId (via parentToolUseId) and finalize it. Also clear any
+      // matching pendingAgentSpawn (sub-agent JSONL never appeared).
+      let subAgents = state.subAgents
+      let pendingAgentSpawns = state.pendingAgentSpawns
+      if (event.toolUseId) {
+        for (const [agentId, sa] of subAgents) {
+          if (sa.parentToolUseId === event.toolUseId) {
+            const next = new Map(subAgents)
+            next.set(agentId, { ...sa, state: nextState, finishedAt: now })
+            subAgents = next
+            break
+          }
+        }
+        if (pendingAgentSpawns.has(event.toolUseId)) {
+          const next = new Map(pendingAgentSpawns)
+          next.delete(event.toolUseId)
+          pendingAgentSpawns = next
+        }
+      }
+      return { ...state, items, subAgents, pendingAgentSpawns }
+    }
+
+    case 'sub_agent_started': {
+      if (state.turnStartedAt === 0) return state
+      // Already known? (Defensive — re-attach can re-emit.)
+      if (state.subAgents.has(event.agentId)) return state
+      // Try to correlate by prompt-text against pendingAgentSpawns. On
+      // hit: move pending → subAgents, link the matching [Main]
+      // ChecklistItem via spawnedAgentId, and consume the pending entry.
+      // On miss: register as orphan; the parent's tool_use may arrive
+      // later (reverse race) and adopt via the tool_use case.
+      let parentToolUseId: string | null = null
+      let description = '(uncorrelated)'
+      let subagentType: string | undefined
+      let pendingAgentSpawns = state.pendingAgentSpawns
+      let items = state.items
+      for (const [parentId, pending] of pendingAgentSpawns) {
+        if (pending.promptText === event.firstPromptText) {
+          parentToolUseId = parentId
+          description = pending.description
+          subagentType = pending.subagentType
+          const nextPending = new Map(pendingAgentSpawns)
+          nextPending.delete(parentId)
+          pendingAgentSpawns = nextPending
+          // Link the [Main] checklist item back so renderer can keep
+          // its 🤖 state consistent.
+          items = items.map((it) =>
+            it.toolUseId === parentId
+              ? { ...it, spawnedAgentId: event.agentId }
+              : it,
+          )
+          break
+        }
+      }
+      const sub: SubAgentState = {
+        agentId: event.agentId,
+        description,
+        subagentType: subagentType ?? event.subagentType,
+        parentToolUseId,
+        state: 'running',
+        startedAt: now,
+        toolCount: 0,
+        firstPromptText: event.firstPromptText,
+        nestedSpawnCount: 0,
+      }
+      const subAgents = new Map(state.subAgents)
+      subAgents.set(event.agentId, sub)
+      return { ...state, subAgents, pendingAgentSpawns, items }
+    }
+
+    case 'sub_agent_tool_use': {
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      const next = new Map(state.subAgents)
+      next.set(event.agentId, {
+        ...sa,
+        toolCount: sa.toolCount + 1,
+        currentTool: event.toolUseId
+          ? {
+              tool: event.toolName,
+              label: toolLabel(event.toolName, event.input),
+              toolUseId: event.toolUseId,
+              startedAt: now,
+            }
+          : sa.currentTool,
+      })
+      return { ...state, subAgents: next }
+    }
+
+    case 'sub_agent_tool_result': {
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      // Per design §3.3: per-tool errors don't fail the agent; only the
+      // parent's tool_result does. We just clear currentTool if it
+      // matches.
+      if (sa.currentTool && sa.currentTool.toolUseId === event.toolUseId) {
+        const next = new Map(state.subAgents)
+        next.set(event.agentId, { ...sa, currentTool: undefined })
+        return { ...state, subAgents: next }
+      }
+      return state
+    }
+
+    case 'sub_agent_turn_end': {
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      // Tentative close: parent's tool_result is still authoritative.
+      // If it later arrives with isError=true, the tool_result case
+      // overrides this 'done' with 'failed'.
+      const next = new Map(state.subAgents)
+      next.set(event.agentId, { ...sa, state: 'done', finishedAt: now })
+      return { ...state, subAgents: next }
+    }
+
+    case 'sub_agent_nested_spawn': {
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      const next = new Map(state.subAgents)
+      next.set(event.agentId, { ...sa, nestedSpawnCount: sa.nestedSpawnCount + 1 })
+      return { ...state, subAgents: next }
     }
 
     case 'turn_end': {
@@ -240,7 +419,20 @@ export function reduce(
       const items = state.items.map((it) =>
         it.state === 'running' ? { ...it, state: 'done' as const, finishedAt: now } : it,
       )
-      return { ...state, items, stage: 'done', thinking: false }
+      // Close any still-running sub-agents + clear pending spawns that
+      // never correlated.
+      const subAgents = new Map<string, SubAgentState>()
+      for (const [k, sa] of state.subAgents) {
+        subAgents.set(k, sa.state === 'running' ? { ...sa, state: 'done', finishedAt: now } : sa)
+      }
+      return {
+        ...state,
+        items,
+        subAgents,
+        pendingAgentSpawns: new Map(),
+        stage: 'done',
+        thinking: false,
+      }
     }
 
     case 'dequeue':

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -33,7 +33,8 @@ import {
   type FSWatcher,
 } from 'fs'
 import { homedir } from 'os'
-import { join } from 'path'
+import { basename, join } from 'path'
+import { isMultiAgentEnabled } from './progress-card.js'
 
 /** Match Claude Code's cli.js VX() function. */
 export function sanitizeCwdToProjectName(cwd: string): string {
@@ -88,6 +89,14 @@ export type SessionEvent =
   | { kind: 'text'; text: string }
   | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean }
   | { kind: 'turn_end'; durationMs: number }
+  // Multi-agent: sub-agent-scoped events. agentId is the sub-agent JSONL
+  // filename stem (e.g. "aac6f1…"). Routed through the same ingest path
+  // as parent events; the reducer fans them out to per-sub-agent state.
+  | { kind: 'sub_agent_started'; agentId: string; firstPromptText: string; subagentType?: string }
+  | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown> }
+  | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean }
+  | { kind: 'sub_agent_turn_end'; agentId: string }
+  | { kind: 'sub_agent_nested_spawn'; agentId: string }
 
 /**
  * Parse the inbound channel XML wrapper to pull out chat_id, message_id,
@@ -197,6 +206,116 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     return [
       { kind: 'turn_end', durationMs: (obj.durationMs as number | undefined) ?? 0 },
     ]
+  }
+
+  return []
+}
+
+/**
+ * Project a single line from a sub-agent JSONL into SessionEvent(s).
+ *
+ * Sub-agent JSONLs (under `<sessionId>/subagents/agent-<agentId>.jsonl`)
+ * use the same line shapes as the parent transcript but with `isSidechain: true`
+ * and an `agentId` field on every line. The first `type=user` message in
+ * the file holds the full prompt text the parent passed in via the
+ * `Agent` tool — that's our correlation key.
+ *
+ * Caller passes the `agentId` extracted from the filename and a stateful
+ * `hasEmittedStart` flag (one per file) so the very first user message
+ * fires `sub_agent_started` exactly once. Subsequent user messages carry
+ * tool_results.
+ *
+ * Sub-agents that themselves spawn more Agent/Task calls fire a
+ * `sub_agent_nested_spawn` event so the parent sub-agent line can render
+ * `(spawned N)`. We do NOT expose nested sub-agent activity as top-level
+ * rows — the design doc explicitly punts on recursion (§5.5).
+ */
+export function projectSubagentLine(
+  line: string,
+  agentId: string,
+  state: { hasEmittedStart: boolean },
+): SessionEvent[] {
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(line)
+  } catch {
+    return []
+  }
+  const type = obj.type as string | undefined
+  if (!type) return []
+
+  if (type === 'user') {
+    const message = obj.message as Record<string, unknown> | undefined
+    const content = message?.content
+    // First user message: the prompt body. Claude Code writes it as a
+    // string for the kickoff message, then as content arrays of
+    // tool_results for subsequent user messages.
+    if (!state.hasEmittedStart) {
+      state.hasEmittedStart = true
+      let promptText = ''
+      if (typeof content === 'string') {
+        promptText = content
+      } else if (Array.isArray(content)) {
+        // Some shapes wrap the prompt in a [{type: 'text', text: '…'}]
+        // block. Handle defensively.
+        for (const c of content) {
+          if (typeof c === 'object' && c != null && (c as Record<string, unknown>).type === 'text') {
+            promptText = String((c as Record<string, unknown>).text ?? '')
+            break
+          }
+        }
+      }
+      return [{ kind: 'sub_agent_started', agentId, firstPromptText: promptText }]
+    }
+    // Subsequent user messages = tool_results
+    if (!Array.isArray(content)) return []
+    const events: SessionEvent[] = []
+    for (const c of content) {
+      if (typeof c !== 'object' || c == null) continue
+      const cc = c as Record<string, unknown>
+      if (cc.type === 'tool_result') {
+        events.push({
+          kind: 'sub_agent_tool_result',
+          agentId,
+          toolUseId: (cc.tool_use_id as string | undefined) ?? '',
+          isError: cc.is_error === true ? true : undefined,
+        })
+      }
+    }
+    return events
+  }
+
+  if (type === 'assistant') {
+    const message = obj.message as Record<string, unknown> | undefined
+    const content = message?.content as Array<Record<string, unknown>> | undefined
+    if (!Array.isArray(content)) return []
+    const events: SessionEvent[] = []
+    for (const c of content) {
+      const ct = c.type as string | undefined
+      if (ct === 'tool_use') {
+        const name = (c.name as string | undefined) ?? ''
+        // A nested Agent/Task call inside a sub-agent: count it as a
+        // nested spawn so the parent sub-agent line shows (spawned N),
+        // but ALSO emit it as a regular tool_use for the sub-agent's
+        // own tool count (sub-agent A's own Agent call is still a tool
+        // it ran — chrono ordering needs to see it).
+        events.push({
+          kind: 'sub_agent_tool_use',
+          agentId,
+          toolUseId: (c.id as string | undefined) ?? null,
+          toolName: name,
+          input: (c.input as Record<string, unknown> | undefined) ?? undefined,
+        })
+        if (name === 'Agent' || name === 'Task') {
+          events.push({ kind: 'sub_agent_nested_spawn', agentId })
+        }
+      }
+    }
+    return events
+  }
+
+  if (type === 'system' && obj.subtype === 'turn_duration') {
+    return [{ kind: 'sub_agent_turn_end', agentId }]
   }
 
   return []
@@ -341,6 +460,126 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     }
   }
 
+  // ─── Sub-agent JSONL tailing (multi-agent path, gated by feature flag) ──
+  //
+  // Each sub-agent gets its own per-file tailer keyed by absolute path.
+  // We poll the `<sessionId>/subagents/` directory on every rescan (cheap,
+  // a few stat calls) so newly-created sub-agent JSONLs are picked up
+  // even when fs.watch on the parent dir is unreliable. Once attached,
+  // a per-file watch + cursor handles incremental reads exactly the way
+  // the parent tail does — and exactly the same per-file cursor map
+  // pattern from PR #25 protects against re-attach truncation.
+  const multiAgent = isMultiAgentEnabled()
+
+  interface SubTail {
+    agentId: string
+    file: string
+    cursor: number
+    pendingPartial: string
+    hasEmittedStart: boolean
+    watcher: FSWatcher | null
+  }
+  const subTails = new Map<string, SubTail>() // keyed by absolute file path
+
+  function readSub(t: SubTail): void {
+    if (stopped) return
+    try {
+      const stat = statSync(t.file)
+      if (stat.size < t.cursor) {
+        t.cursor = 0
+        t.pendingPartial = ''
+      }
+      if (stat.size === t.cursor) return
+      const buf = Buffer.alloc(stat.size - t.cursor)
+      const fd = openSync(t.file, 'r')
+      try {
+        readSync(fd, buf, 0, buf.length, t.cursor)
+      } finally {
+        closeSync(fd)
+      }
+      t.cursor = stat.size
+      const text = t.pendingPartial + buf.toString('utf-8')
+      const lines = text.split('\n')
+      t.pendingPartial = lines.pop() ?? ''
+      const startState = { hasEmittedStart: t.hasEmittedStart }
+      for (const line of lines) {
+        if (!line) continue
+        const events = projectSubagentLine(line, t.agentId, startState)
+        for (const ev of events) {
+          try {
+            onEvent(ev)
+          } catch (err) {
+            log?.(`session-tail: sub onEvent threw: ${(err as Error).message}`)
+          }
+        }
+      }
+      t.hasEmittedStart = startState.hasEmittedStart
+    } catch (err) {
+      log?.(`session-tail: sub read failed: ${(err as Error).message}`)
+    }
+  }
+
+  function attachSub(file: string, agentId: string): void {
+    if (subTails.has(file)) return
+    let cursor = 0
+    try {
+      cursor = statSync(file).size
+    } catch { /* ignore */ }
+    // Sub-agent JSONLs are typically created and immediately written; we
+    // start at byte 0 so we DON'T miss the first user-message line that
+    // carries the prompt text needed for correlation. This differs from
+    // the parent tail which seeks to end (parent has long history).
+    const t: SubTail = {
+      agentId,
+      file,
+      cursor: 0, // intentionally 0: read from start to capture prompt
+      pendingPartial: '',
+      hasEmittedStart: false,
+      watcher: null,
+    }
+    void cursor
+    try {
+      t.watcher = watch(file, () => readSub(t))
+    } catch (err) {
+      log?.(`session-tail: sub fs.watch failed (${(err as Error).message})`)
+    }
+    subTails.set(file, t)
+    log?.(`session-tail: attached sub ${agentId} (${file})`)
+    readSub(t)
+  }
+
+  /**
+   * Sub-agent dir lives next to the parent JSONL: if the parent file is
+   * `<projectsDir>/<sessionId>.jsonl`, sub-agents live under
+   * `<projectsDir>/<sessionId>/subagents/agent-<agentId>.jsonl`.
+   *
+   * Claude Code 2.1.x has been observed to use this layout. If a future
+   * release renames `agent-*.jsonl`, the glob check below is the only
+   * place to update.
+   */
+  function rescanSubagents(): void {
+    if (!multiAgent) return
+    if (!currentFile) return
+    const sessionId = basename(currentFile, '.jsonl')
+    const subDir = join(projectsDir, sessionId, 'subagents')
+    if (!existsSync(subDir)) return
+    let entries: string[]
+    try {
+      entries = readdirSync(subDir)
+    } catch { return }
+    for (const e of entries) {
+      if (!e.startsWith('agent-') || !e.endsWith('.jsonl')) continue
+      const agentId = e.slice('agent-'.length, -'.jsonl'.length)
+      const file = join(subDir, e)
+      if (!subTails.has(file)) {
+        attachSub(file, agentId)
+      } else {
+        // Already attached — defensive read in case fs.watch missed.
+        readSub(subTails.get(file)!)
+      }
+    }
+  }
+
   function rescan(): void {
     if (stopped) return
     const file = findActiveSessionFile(projectsDir)
@@ -350,6 +589,7 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     }
     // Always read in case fs.watch missed an event (common on WSL/network mounts)
     readNew()
+    rescanSubagents()
   }
 
   // Initial pass
@@ -363,6 +603,13 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
         try { watcher.close() } catch { /* ignore */ }
         watcher = null
       }
+      for (const t of subTails.values()) {
+        if (t.watcher) {
+          try { t.watcher.close() } catch { /* ignore */ }
+          t.watcher = null
+        }
+      }
+      subTails.clear()
       if (pollTimer) {
         clearInterval(pollTimer)
         pollTimer = null

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -337,3 +337,182 @@ describe('progress-card render', () => {
     expect(diff.length).toBeLessThanOrEqual(2)
   })
 })
+
+// ─── Multi-agent correlation reducer tests ───────────────────────────────
+//
+// Renderer is unchanged in this PR, so we only assert state-shape — the
+// rendered HTML is verified by the renderer PR.
+
+describe('progress-card reducer — multi-agent correlation', () => {
+  it('forward race: parent Agent tool_use stages a pendingAgentSpawn', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'design ux', prompt: 'PROMPT-A', subagent_type: 'researcher' },
+      },
+    ])
+    expect(st.pendingAgentSpawns.size).toBe(1)
+    expect(st.pendingAgentSpawns.get('toolu_p1')?.promptText).toBe('PROMPT-A')
+    expect(st.subAgents.size).toBe(0)
+  })
+
+  it('forward race: sub_agent_started moves pending → subAgents and links checklist item', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'design ux', prompt: 'PROMPT-A' },
+      },
+      { kind: 'sub_agent_started', agentId: 'aaa', firstPromptText: 'PROMPT-A' },
+    ])
+    expect(st.pendingAgentSpawns.size).toBe(0)
+    expect(st.subAgents.size).toBe(1)
+    const sa = st.subAgents.get('aaa')!
+    expect(sa.parentToolUseId).toBe('toolu_p1')
+    expect(sa.description).toBe('design ux')
+    expect(sa.state).toBe('running')
+    // Checklist item linked
+    const agentItem = st.items.find((i) => i.toolUseId === 'toolu_p1')!
+    expect(agentItem.spawnedAgentId).toBe('aaa')
+  })
+
+  it('reverse race: sub_agent_started lands first as orphan, then parent adopts', () => {
+    const st = fold([
+      enqueue('go'),
+      { kind: 'sub_agent_started', agentId: 'bbb', firstPromptText: 'PROMPT-B' },
+    ])
+    expect(st.subAgents.get('bbb')?.parentToolUseId).toBeNull()
+    expect(st.subAgents.get('bbb')?.description).toBe('(uncorrelated)')
+    const st2 = reduce(
+      st,
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p2',
+        input: { description: 'audit', prompt: 'PROMPT-B' },
+      },
+      9999,
+    )
+    expect(st2.pendingAgentSpawns.size).toBe(0)
+    expect(st2.subAgents.get('bbb')?.parentToolUseId).toBe('toolu_p2')
+    expect(st2.subAgents.get('bbb')?.description).toBe('audit')
+  })
+
+  it('two parallel Agent calls with identical prompts: FIFO arrival order assigns', () => {
+    // Parent emits two Agent tool_uses with the SAME prompt text. Two
+    // sub-agent JSONLs appear in some order. Each sub_agent_started
+    // adopts the FIRST remaining pending spawn (FIFO).
+    let st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'first', prompt: 'DUP' },
+      },
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p2',
+        input: { description: 'second', prompt: 'DUP' },
+      },
+    ])
+    st = reduce(st, { kind: 'sub_agent_started', agentId: 'A', firstPromptText: 'DUP' }, 5000)
+    st = reduce(st, { kind: 'sub_agent_started', agentId: 'B', firstPromptText: 'DUP' }, 5100)
+    // Both correlated, deterministic FIFO
+    expect(st.subAgents.get('A')?.parentToolUseId).toBe('toolu_p1')
+    expect(st.subAgents.get('B')?.parentToolUseId).toBe('toolu_p2')
+    expect(st.pendingAgentSpawns.size).toBe(0)
+  })
+
+  it('sub_agent_tool_use increments toolCount and sets currentTool', () => {
+    let st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+    ])
+    st = reduce(
+      st,
+      { kind: 'sub_agent_tool_use', agentId: 'X', toolUseId: 'toolu_x1', toolName: 'Read', input: { file_path: '/f' } },
+      6000,
+    )
+    const sa = st.subAgents.get('X')!
+    expect(sa.toolCount).toBe(1)
+    expect(sa.currentTool?.tool).toBe('Read')
+    // Tool result clears currentTool
+    st = reduce(st, { kind: 'sub_agent_tool_result', agentId: 'X', toolUseId: 'toolu_x1' }, 6100)
+    expect(st.subAgents.get('X')!.currentTool).toBeUndefined()
+  })
+
+  it("parent's tool_result is authoritative: overrides early sub_agent_turn_end on isError", () => {
+    let st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+      { kind: 'sub_agent_turn_end', agentId: 'X' },
+    ])
+    expect(st.subAgents.get('X')?.state).toBe('done')
+    st = reduce(
+      st,
+      { kind: 'tool_result', toolUseId: 'toolu_p1', toolName: 'Agent', isError: true },
+      7000,
+    )
+    expect(st.subAgents.get('X')?.state).toBe('failed')
+  })
+
+  it('sub_agent_nested_spawn increments nestedSpawnCount but does not create a row', () => {
+    let st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'parent', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+    ])
+    st = reduce(st, { kind: 'sub_agent_nested_spawn', agentId: 'X' }, 8000)
+    st = reduce(st, { kind: 'sub_agent_nested_spawn', agentId: 'X' }, 8100)
+    expect(st.subAgents.get('X')?.nestedSpawnCount).toBe(2)
+    expect(st.subAgents.size).toBe(1) // no row for the nested ones
+  })
+
+  it('turn_end closes running sub-agents and clears pending spawns', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p2',
+        input: { description: 'd2', prompt: 'P2' },
+      },
+      // P2's sub-agent JSONL never appears
+      { kind: 'turn_end', durationMs: 1 },
+    ])
+    expect(st.subAgents.get('X')?.state).toBe('done')
+    expect(st.pendingAgentSpawns.size).toBe(0)
+    expect(st.stage).toBe('done')
+  })
+})

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   projectTranscriptLine,
+  projectSubagentLine,
   sanitizeCwdToProjectName,
   getProjectsDirForCwd,
   startSessionTail,
@@ -337,5 +338,68 @@ describe('startSessionTail — re-attach resumes from saved cursor', () => {
     } finally {
       handle.stop()
     }
+  })
+})
+
+describe('projectSubagentLine', () => {
+  it('emits sub_agent_started exactly once for the first user message (string content)', () => {
+    const st = { hasEmittedStart: false }
+    const line = JSON.stringify({
+      isSidechain: true,
+      agentId: 'aaa',
+      type: 'user',
+      message: { role: 'user', content: 'hello sub-agent' },
+    })
+    const events = projectSubagentLine(line, 'aaa', st)
+    expect(events).toEqual([
+      { kind: 'sub_agent_started', agentId: 'aaa', firstPromptText: 'hello sub-agent' },
+    ])
+    expect(st.hasEmittedStart).toBe(true)
+    // Second user message → tool_results, NOT another sub_agent_started
+    const line2 = JSON.stringify({
+      type: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'toolu_x', is_error: false }],
+      },
+    })
+    const events2 = projectSubagentLine(line2, 'aaa', st)
+    expect(events2).toEqual([
+      { kind: 'sub_agent_tool_result', agentId: 'aaa', toolUseId: 'toolu_x', isError: undefined },
+    ])
+  })
+
+  it('emits sub_agent_tool_use for assistant tool_use blocks; nested Agent fires nested_spawn too', () => {
+    const st = { hasEmittedStart: true }
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } },
+          { type: 'tool_use', id: 'toolu_b', name: 'Agent', input: { description: 'nested', prompt: 'nested-p' } },
+        ],
+      },
+    })
+    const events = projectSubagentLine(line, 'X', st)
+    expect(events.length).toBe(3)
+    expect(events[0].kind).toBe('sub_agent_tool_use')
+    expect(events[1].kind).toBe('sub_agent_tool_use')
+    expect(events[2]).toEqual({ kind: 'sub_agent_nested_spawn', agentId: 'X' })
+  })
+
+  it('emits sub_agent_turn_end on system turn_duration', () => {
+    const st = { hasEmittedStart: true }
+    const events = projectSubagentLine(
+      JSON.stringify({ type: 'system', subtype: 'turn_duration', durationMs: 42 }),
+      'X',
+      st,
+    )
+    expect(events).toEqual([{ kind: 'sub_agent_turn_end', agentId: 'X' }])
+  })
+
+  it('skips malformed lines silently', () => {
+    const st = { hasEmittedStart: false }
+    expect(projectSubagentLine('{not-json', 'X', st)).toEqual([])
+    expect(projectSubagentLine('{}', 'X', st)).toEqual([])
+    expect(st.hasEmittedStart).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Per-sub-agent JSONL tailer in \`session-tail.ts\` (gated on \`PROGRESS_CARD_MULTI_AGENT=1\`).
- New \`sub_agent_*\` SessionEvent variants + \`projectSubagentLine()\`.
- Reducer correlation: prompt-text equality, forward + reverse race handled, FIFO disambiguation for duplicate prompts within a turn.
- Parent's \`tool_result\` is authoritative; \`sub_agent_turn_end\` is tentative.

## Stack
1. foundation (#28)
2. **this PR** — correlation
3. renderer
4. rate limit + lifecycle
5. test harness scenarios

## Test plan
- [x] +12 unit tests (8 reducer correlation cases + 4 \`projectSubagentLine\` cases)
- [x] \`bun test\` green (528 pass, was 516)
- [x] \`bunx tsc --noEmit\` clean
- [x] No rendered output change — renderer ignores new state in this PR
- [x] Existing PR #26 harness tests still green (no \`subagents/\` dir created → no behaviour change)

## Note on base branch
Targets \`phase/multi-agent-foundation\` so the diff is reviewable in isolation. Re-target to \`main\` once #28 lands, or merge sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)