### PR TITLE
Multi-agent progress card 4/5: edit-budget guardrail

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -61,6 +61,19 @@ export interface ProgressDriverConfig {
    * any chat has a running turn. Default 5000. Set to 0 to disable.
    */
   heartbeatMs?: number
+  /**
+   * Multi-agent rate-limit guardrail (design §4.4). Telegram caps edits
+   * at ~20/min/chat. With N parallel sub-agents emitting bursty events
+   * the default 400ms coalesce + 500ms floor can exceed the cap. When
+   * we observe more than `editBudgetThreshold` edits in the trailing
+   * 60s for a chat, the coalesce window expands to `editBudgetCoalesceMs`
+   * until the rate drops back. Heartbeat is also suppressed while the
+   * budget is hot.
+   *
+   * Defaults: threshold=18, coalesce window when hot=3000ms.
+   */
+  editBudgetThreshold?: number
+  editBudgetCoalesceMs?: number
 }
 
 /**
@@ -142,6 +155,27 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       clearInterval(handle)
     })
   const heartbeatMs = config.heartbeatMs ?? 5000
+  const editBudgetThreshold = config.editBudgetThreshold ?? 18
+  const editBudgetCoalesceMs = config.editBudgetCoalesceMs ?? 3000
+  // Per-chat sliding 60s window of recent emit timestamps. When the
+  // window holds more than `editBudgetThreshold` entries we're "hot"
+  // and coalesce more aggressively.
+  const editTimestamps = new Map<string, number[]>()
+  function recordEdit(k: string): void {
+    const arr = editTimestamps.get(k) ?? []
+    arr.push(now())
+    // Drop entries older than 60s.
+    const cutoff = now() - 60_000
+    while (arr.length > 0 && arr[0] < cutoff) arr.shift()
+    editTimestamps.set(k, arr)
+  }
+  function isBudgetHot(k: string): boolean {
+    const arr = editTimestamps.get(k)
+    if (!arr) return false
+    const cutoff = now() - 60_000
+    while (arr.length > 0 && arr[0] < cutoff) arr.shift()
+    return arr.length >= editBudgetThreshold
+  }
 
   const chats = new Map<string, PerChatState>()
   // Track the last enqueued chat so non-enqueue session events (tool_use,
@@ -173,6 +207,11 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       // (rounded to the heartbeat period) advanced.
       for (const [k, cs] of chats) {
         if (cs.state.stage === 'done') continue
+        // Skip heartbeat while the chat is hot — sub-agent bursts are
+        // already producing edits, the elapsed counter is ticking from
+        // those, and an extra heartbeat edit just spends budget. (Design
+        // §4.4: "heartbeat respects budget too".)
+        if (isBudgetHot(k)) continue
         const html = render(cs.state, now())
         const bucket = Math.floor(now() / heartbeatMs)
         const prevBucket = lastHeartbeatBucket.get(k)
@@ -180,6 +219,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         lastHeartbeatBucket.set(k, bucket)
         cs.lastEmittedHtml = html
         cs.lastEmittedAt = now()
+        recordEdit(k)
         config.emit({
           chatId: cs.chatId,
           threadId: cs.threadId,
@@ -208,6 +248,8 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     if (html === chatState.lastEmittedHtml && !forceDone) return
     chatState.lastEmittedHtml = html
     chatState.lastEmittedAt = now()
+    const k = key(chatState.chatId, chatState.threadId)
+    recordEdit(k)
     config.emit({
       chatId: chatState.chatId,
       threadId: chatState.threadId,
@@ -310,6 +352,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           // Drop the chat state so a subsequent turn starts clean.
           chats.delete(k)
           lastHeartbeatBucket.delete(k)
+          editTimestamps.delete(k)
           if (currentChatId === chatId && currentThreadId === threadId) {
             currentChatId = null
             currentThreadId = undefined
@@ -331,8 +374,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       // defer to at least minIntervalMs after the last emit. Also always
       // coalesce bursts — even a burst that runs past minIntervalMs gets
       // at most one flush per coalesce window.
+      //
+      // Multi-agent rate-limit: if the chat has emitted >threshold edits
+      // in the last 60s, expand the coalesce window to
+      // editBudgetCoalesceMs (default 3s) so the Telegram 20/min cap is
+      // never exceeded by sub-agent bursts.
       const sinceLast = now() - chatState.lastEmittedAt
-      const delay = Math.max(coalesceMs, minIntervalMs - sinceLast, 0)
+      const effectiveCoalesce = isBudgetHot(k) ? editBudgetCoalesceMs : coalesceMs
+      const delay = Math.max(effectiveCoalesce, minIntervalMs - sinceLast, 0)
       chatState.pendingTimer = setT(() => {
         // Defensive: if the chat was deleted between schedule and fire
         // (e.g. a turn_end racing with an async boundary added later),

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -421,3 +421,78 @@ describe('summariseTurn', () => {
     expect(summariseTurn(s, 2000)).toBe('1 tool, 1s')
   })
 })
+
+describe('progress-card driver — multi-agent rate limit', () => {
+  it('expands coalesce window once edit budget is hot (>18 in 60s)', () => {
+    // Use a small threshold so we can exercise the path without
+    // simulating 18 distinct events. editBudgetCoalesceMs=2000, threshold=3.
+    let now = 1000
+    const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+    let nextRef = 0
+    const emits: Array<{ chatId: string; html: string; done: boolean }> = []
+    const driver = createProgressDriver({
+      emit: (a) => emits.push({ chatId: a.chatId, html: a.html, done: a.done }),
+      minIntervalMs: 100,
+      coalesceMs: 100,
+      heartbeatMs: 0,
+      editBudgetThreshold: 3,
+      editBudgetCoalesceMs: 2000,
+      now: () => now,
+      setTimeout: (fn, ms) => {
+        const ref = nextRef++
+        timers.push({ fireAt: now + ms, fn, ref })
+        return { ref }
+      },
+      clearTimeout: (h) => {
+        const t = (h as { ref: number }).ref
+        const i = timers.findIndex((x) => x.ref === t)
+        if (i !== -1) timers.splice(i, 1)
+      },
+      setInterval: (fn, ms) => {
+        const ref = nextRef++
+        timers.push({ fireAt: now + ms, fn, ref, repeat: ms })
+        return { ref }
+      },
+      clearInterval: (h) => {
+        const t = (h as { ref: number }).ref
+        const i = timers.findIndex((x) => x.ref === t)
+        if (i !== -1) timers.splice(i, 1)
+      },
+    })
+    const advance = (ms: number): void => {
+      now += ms
+      for (;;) {
+        timers.sort((a, b) => a.fireAt - b.fireAt)
+        const t = timers[0]
+        if (!t || t.fireAt > now) break
+        if (t.repeat != null) { t.fireAt += t.repeat; t.fn() } else { timers.shift(); t.fn() }
+      }
+    }
+
+    // Fire 4 distinct visible-state events 200ms apart — each forces an
+    // emit (well past the 100ms coalesce). After 3 emits we go hot.
+    driver.ingest(
+      { kind: 'enqueue', chatId: 'c', messageId: '1', threadId: null, rawContent: '<channel chat_id="c">go</channel>' },
+      null,
+    )
+    expect(emits.length).toBe(1) // enqueue is immediate
+
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 'a', input: { file_path: '/x' } }, 'c')
+    advance(200)
+    driver.ingest({ kind: 'tool_result', toolUseId: 'a', toolName: 'Read' }, 'c')
+    advance(200)
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 'b', input: { file_path: '/y' } }, 'c')
+    advance(200)
+    // Should have ~4 emits by now (enqueue + 3 visible updates). Now hot.
+    const emitsBeforeHot = emits.length
+    expect(emitsBeforeHot).toBeGreaterThanOrEqual(3)
+
+    // Schedule another visible event. With budget hot, coalesce expands
+    // to 2000ms so a 500ms wait must NOT fire it.
+    driver.ingest({ kind: 'tool_result', toolUseId: 'b', toolName: 'Read' }, 'c')
+    advance(500)
+    expect(emits.length).toBe(emitsBeforeHot) // suppressed by hot coalesce
+    advance(2000)
+    expect(emits.length).toBe(emitsBeforeHot + 1) // finally fires
+  })
+})


### PR DESCRIPTION
## Summary
- Per-chat sliding 60s window tracks recent emit timestamps.
- Coalesce window expands from 400ms to 3000ms once \`>=editBudgetThreshold\` (default 18) edits land in 60s.
- Heartbeat suppressed while a chat is hot — sub-agent events are already producing edits.
- editTimestamps cleared on \`turn_end\`.

## Stack
1. foundation (#28)
2. correlation (#29)
3. renderer (#30)
4. **this PR** — rate limit + lifecycle
5. test harness scenarios

## Test plan
- [x] +1 driver test with threshold=3, 2s expanded coalesce, asserting suppressed-then-fired emit
- [x] \`bun test\` green (533 pass)
- [x] \`bunx tsc --noEmit\` clean
- [x] No behaviour change for normal-rate chats (default threshold=18 not reached in PR #26 harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)