### PR TITLE
Multi-agent progress card 5/5: integration harness scenarios

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -272,6 +272,24 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     for (let i = 0; i < a.items.length; i++) {
       if (a.items[i].state !== b.items[i].state) return true
       if (a.items[i].tool !== b.items[i].tool) return true
+      // Multi-agent: spawnedAgentId attached on correlation matters for
+      // the [Main] line's 🤖 vs ✅ glyph (PR 3 renderer).
+      if (a.items[i].spawnedAgentId !== b.items[i].spawnedAgentId) return true
+    }
+    // Multi-agent: any change in sub-agent shape or per-sub-agent state
+    // is user-visible. Cheap O(N) scan; N is the sub-agent count, which
+    // is bounded by how many parallel Agent calls one turn makes (~4–12
+    // in practice).
+    if (a.subAgents.size !== b.subAgents.size) return true
+    for (const [k, sa] of a.subAgents) {
+      const sb = b.subAgents.get(k)
+      if (!sb) return true
+      if (sa.state !== sb.state) return true
+      if (sa.toolCount !== sb.toolCount) return true
+      if (sa.description !== sb.description) return true
+      if (sa.parentToolUseId !== sb.parentToolUseId) return true
+      if (sa.nestedSpawnCount !== sb.nestedSpawnCount) return true
+      if ((sa.currentTool?.toolUseId ?? null) !== (sb.currentTool?.toolUseId ?? null)) return true
     }
     return false
   }

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -294,20 +294,22 @@ export function projectSubagentLine(
       const ct = c.type as string | undefined
       if (ct === 'tool_use') {
         const name = (c.name as string | undefined) ?? ''
-        // A nested Agent/Task call inside a sub-agent: count it as a
-        // nested spawn so the parent sub-agent line shows (spawned N),
-        // but ALSO emit it as a regular tool_use for the sub-agent's
-        // own tool count (sub-agent A's own Agent call is still a tool
-        // it ran — chrono ordering needs to see it).
-        events.push({
-          kind: 'sub_agent_tool_use',
-          agentId,
-          toolUseId: (c.id as string | undefined) ?? null,
-          toolName: name,
-          input: (c.input as Record<string, unknown> | undefined) ?? undefined,
-        })
+        // Nested Agent/Task call inside a sub-agent: track ONLY as a
+        // nested_spawn count (renders as "(spawned N)" suffix on the
+        // parent sub-agent line). Per design §5.5 we do NOT expose
+        // sub-sub-agent activity as the parent sub-agent's currentTool —
+        // that would surface the sub-sub-agent's description and break
+        // the "no recursion in rendering" rule.
         if (name === 'Agent' || name === 'Task') {
           events.push({ kind: 'sub_agent_nested_spawn', agentId })
+        } else {
+          events.push({
+            kind: 'sub_agent_tool_use',
+            agentId,
+            toolUseId: (c.id as string | undefined) ?? null,
+            toolName: name,
+            input: (c.input as Record<string, unknown> | undefined) ?? undefined,
+          })
         }
       }
     }

--- a/telegram-plugin/tests/progress-card-harness.test.ts
+++ b/telegram-plugin/tests/progress-card-harness.test.ts
@@ -371,3 +371,295 @@ describe('progress-card integration harness', () => {
     driver.dispose?.()
   })
 })
+
+// ─── Multi-agent integration scenarios (design doc §5) ───────────────────
+//
+// These mirror §5.1–§5.7 of telegram-plugin/docs/multi-agent-card-design.md.
+// Each scenario exercises the full pipeline (tail + correlation + render)
+// with PROGRESS_CARD_MULTI_AGENT=1. §5.8 (rate-limit budget) is covered
+// by the driver unit test instead — it needs a synthetic clock.
+//
+// The harness materializes a `<sessionId>/subagents/agent-<id>.jsonl`
+// file alongside the parent JSONL so the new tail subdir watcher picks
+// it up.
+
+const subAgentUserLine = (promptText: string): string =>
+  JSON.stringify({
+    isSidechain: true,
+    type: 'user',
+    message: { role: 'user', content: promptText },
+  }) + '\n'
+
+const subAgentToolUseLine = (toolUseId: string, name: string, input: Record<string, unknown>): string =>
+  JSON.stringify({
+    isSidechain: true,
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id: toolUseId, name, input }] },
+  }) + '\n'
+
+const subAgentToolResultLine = (toolUseId: string, isError = false): string =>
+  JSON.stringify({
+    isSidechain: true,
+    type: 'user',
+    message: { content: [{ type: 'tool_result', tool_use_id: toolUseId, is_error: isError }] },
+  }) + '\n'
+
+const subAgentTurnEndLine = (): string =>
+  JSON.stringify({ isSidechain: true, type: 'system', subtype: 'turn_duration', durationMs: 1 }) + '\n'
+
+const parentAgentToolUseLine = (toolUseId: string, description: string, prompt: string, subagentType = 'researcher'): string =>
+  JSON.stringify({
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          id: toolUseId,
+          name: 'Agent',
+          input: { subagent_type: subagentType, description, prompt },
+        },
+      ],
+    },
+  }) + '\n'
+
+function mkSubagentJsonl(projectsDir: string, sessionStem: string, agentId: string): string {
+  const dir = join(projectsDir, sessionStem, 'subagents')
+  mkdirSync(dir, { recursive: true })
+  const file = join(dir, `agent-${agentId}.jsonl`)
+  writeFileSync(file, '')
+  return file
+}
+
+describe('progress-card multi-agent harness', () => {
+  const FLAG = 'PROGRESS_CARD_MULTI_AGENT'
+  function withFlag<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = process.env[FLAG]
+    process.env[FLAG] = '1'
+    return fn().finally(() => {
+      if (prev != null) process.env[FLAG] = prev
+      else delete process.env[FLAG]
+    })
+  }
+
+  it('5.1 — 4 parallel sub-agents, all correlate', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit,
+        coalesceMs: 20,
+        minIntervalMs: 20,
+        heartbeatMs: 0,
+      })
+      const sessionStem = 'session-A'
+      const parent = join(projectsDir, `${sessionStem}.jsonl`)
+      writeFileSync(parent, '')
+
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'fan out 4 investigators'))
+        for (let i = 1; i <= 4; i++) {
+          appendFileSync(parent, parentAgentToolUseLine(`toolu_p${i}`, `task ${i}`, `PROMPT-${i}`))
+        }
+        await wait(150)
+
+        // Pre-correlation: [Main] shows Agent lines but no [Sub-agents] block
+        const preHtml = bot.edits[bot.edits.length - 1].html
+        expect(preHtml).toContain('[Main')
+        expect(preHtml).toContain('task 1')
+        expect(preHtml).toContain('task 4')
+        expect(preHtml).not.toContain('[Sub-agents')
+
+        // Now create 4 sub-agent JSONLs in random-ish order with matching prompts
+        const order = [3, 1, 4, 2]
+        for (const i of order) {
+          const file = mkSubagentJsonl(projectsDir, sessionStem, `aid${i}`)
+          appendFileSync(file, subAgentUserLine(`PROMPT-${i}`))
+        }
+        await wait(200)
+
+        const html = bot.edits[bot.edits.length - 1].html
+        expect(html).toContain('[Sub-agents · 4 running]')
+        for (let i = 1; i <= 4; i++) {
+          expect(html).toContain(`task ${i}`)
+        }
+
+        // Each sub-agent emits a Read tool_use
+        for (let i = 1; i <= 4; i++) {
+          const file = join(projectsDir, sessionStem, 'subagents', `agent-aid${i}.jsonl`)
+          appendFileSync(file, subAgentToolUseLine(`toolu_s${i}`, 'Read', { file_path: `/f${i}` }))
+        }
+        await wait(200)
+        const midHtml = bot.edits[bot.edits.length - 1].html
+        expect(midHtml).toContain('└ 🔧')
+
+        // Parent tool_results for all 4
+        for (let i = 1; i <= 4; i++) {
+          appendFileSync(parent, toolResultLine(`toolu_p${i}`))
+        }
+        appendFileSync(parent, turnEndLine())
+        await wait(250)
+
+        const finalHtml = bot.edits[bot.edits.length - 1].html
+        expect(finalHtml).toMatch(/\[Sub-agents · 4 done\]/)
+        const doneEdits = bot.edits.filter((e) => e.done)
+        expect(doneEdits.length).toBeGreaterThanOrEqual(1)
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+
+  it('5.2 — sub-agent finishes before parent tool_result (early ✅, then isError flips ❌)', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit, coalesceMs: 20, minIntervalMs: 20, heartbeatMs: 0,
+      })
+      const stem = 'session-B'
+      const parent = join(projectsDir, `${stem}.jsonl`)
+      writeFileSync(parent, '')
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'one sub'))
+        appendFileSync(parent, parentAgentToolUseLine('toolu_p1', 'investigate', 'PA'))
+        const sub = mkSubagentJsonl(projectsDir, stem, 'aidX')
+        appendFileSync(sub, subAgentUserLine('PA'))
+        appendFileSync(sub, subAgentTurnEndLine())
+        await wait(200)
+        const earlyHtml = bot.edits[bot.edits.length - 1].html
+        // Tentative ✅ for the sub-agent on early turn_end
+        expect(earlyHtml).toMatch(/✅ investigate/)
+        // Parent tool_result with isError=true overrides → ❌
+        appendFileSync(parent, toolResultLine('toolu_p1', true))
+        appendFileSync(parent, turnEndLine())
+        await wait(250)
+        const finalHtml = bot.edits[bot.edits.length - 1].html
+        expect(finalHtml).toMatch(/❌ investigate/)
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+
+  it('5.3 — sub-agent JSONL appears AFTER parent tool_use (forward race)', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit, coalesceMs: 20, minIntervalMs: 20, heartbeatMs: 0,
+      })
+      const stem = 'session-C'
+      const parent = join(projectsDir, `${stem}.jsonl`)
+      writeFileSync(parent, '')
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'race fwd'))
+        appendFileSync(parent, parentAgentToolUseLine('toolu_p1', 'thing', 'PROMPT-X'))
+        await wait(120)
+        const before = bot.edits[bot.edits.length - 1].html
+        expect(before).not.toContain('[Sub-agents')
+        // Now create the JSONL
+        const sub = mkSubagentJsonl(projectsDir, stem, 'aidA')
+        appendFileSync(sub, subAgentUserLine('PROMPT-X'))
+        await wait(200)
+        const after = bot.edits[bot.edits.length - 1].html
+        expect(after).toContain('[Sub-agents')
+        expect(after).toContain('thing')
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+
+  it('5.4 — sub-agent JSONL appears BEFORE parent tool_use (reverse race adoption)', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit, coalesceMs: 20, minIntervalMs: 20, heartbeatMs: 0,
+      })
+      const stem = 'session-D'
+      const parent = join(projectsDir, `${stem}.jsonl`)
+      writeFileSync(parent, '')
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'race rev'))
+        // Create sub JSONL first with prompt; no parent tool_use yet
+        const sub = mkSubagentJsonl(projectsDir, stem, 'aidR')
+        appendFileSync(sub, subAgentUserLine('PROMPT-Y'))
+        await wait(200)
+        const orphanHtml = bot.edits[bot.edits.length - 1].html
+        expect(orphanHtml).toContain('(uncorrelated)')
+        // Now parent emits the Agent tool_use → adoption
+        appendFileSync(parent, parentAgentToolUseLine('toolu_p1', 'reverse race target', 'PROMPT-Y'))
+        await wait(200)
+        const adoptedHtml = bot.edits[bot.edits.length - 1].html
+        expect(adoptedHtml).toContain('reverse race target')
+        expect(adoptedHtml).not.toContain('(uncorrelated)')
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+
+  it('5.5 — sub-sub-agent renders only as (spawned N) suffix on parent', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit, coalesceMs: 20, minIntervalMs: 20, heartbeatMs: 0,
+      })
+      const stem = 'session-E'
+      const parent = join(projectsDir, `${stem}.jsonl`)
+      writeFileSync(parent, '')
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'nested'))
+        appendFileSync(parent, parentAgentToolUseLine('toolu_p1', 'parent sub', 'PROMPT-N'))
+        const subA = mkSubagentJsonl(projectsDir, stem, 'aidA')
+        appendFileSync(subA, subAgentUserLine('PROMPT-N'))
+        // Sub-agent A emits a nested Agent call (sub-sub-agent)
+        appendFileSync(
+          subA,
+          subAgentToolUseLine('toolu_inner', 'Agent', { description: 'inner', prompt: 'PROMPT-INNER' }),
+        )
+        await wait(250)
+        const html = bot.edits[bot.edits.length - 1].html
+        expect(html).toContain('parent sub')
+        expect(html).toContain('(spawned 1)')
+        // Sub-sub-agent must NOT appear as its own row
+        expect(html).not.toContain('inner')
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+})

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -368,7 +368,7 @@ describe('projectSubagentLine', () => {
     ])
   })
 
-  it('emits sub_agent_tool_use for assistant tool_use blocks; nested Agent fires nested_spawn too', () => {
+  it('emits sub_agent_tool_use for regular tools; nested Agent fires ONLY nested_spawn', () => {
     const st = { hasEmittedStart: true }
     const line = JSON.stringify({
       type: 'assistant',
@@ -380,10 +380,14 @@ describe('projectSubagentLine', () => {
       },
     })
     const events = projectSubagentLine(line, 'X', st)
-    expect(events.length).toBe(3)
+    // 2 events: 1 sub_agent_tool_use (Read) + 1 nested_spawn (the Agent).
+    // Per design §5.5 we do NOT also emit sub_agent_tool_use for the
+    // nested Agent — that would surface the sub-sub-agent's description
+    // as the parent sub-agent's currentTool and break "no recursion in
+    // rendering."
+    expect(events.length).toBe(2)
     expect(events[0].kind).toBe('sub_agent_tool_use')
-    expect(events[1].kind).toBe('sub_agent_tool_use')
-    expect(events[2]).toEqual({ kind: 'sub_agent_nested_spawn', agentId: 'X' })
+    expect(events[1]).toEqual({ kind: 'sub_agent_nested_spawn', agentId: 'X' })
   })
 
   it('emits sub_agent_turn_end on system turn_duration', () => {


### PR DESCRIPTION
## Summary
Five new end-to-end harness tests in \`tests/progress-card-harness.test.ts\` exercising the full pipeline (real session-tail + driver + reducer + renderer) for the multi-agent scenarios in design doc §5.

- 5.1 — 4 parallel sub-agents, all correlate
- 5.2 — sub-agent early ✅ then parent isError → ❌
- 5.3 — forward race (parent tool_use before sub JSONL)
- 5.4 — reverse race (sub JSONL before parent tool_use, adoption)
- 5.5 — sub-sub-agent renders only as \`(spawned N)\`

§5.6 (overflow), §5.7 (malformed), §5.8 (rate-limit budget) deferred — see commit message for justification.

## Code fixes folded in (small, load-bearing for the harness)
- \`session-tail.ts\`: nested Agent/Task in a sub-agent emits ONLY \`sub_agent_nested_spawn\`, never \`sub_agent_tool_use\`. Otherwise the sub-sub-agent's description leaks into the parent sub-agent's currentTool. Conceptually belongs in PR 2/3 but the test that proves it lives here.
- \`progress-card-driver.ts\`: \`visibleDiff()\` now also compares the \`subAgents\` map and \`spawnedAgentId\` on items. Without this, \`sub_agent_*\` events mutated state but never scheduled a flush — the \`[Sub-agents]\` section never rendered. Conceptually belongs in PR 4.

## Stack
1. foundation (#28)
2. correlation (#29)
3. renderer (#30)
4. rate limit (#31)
5. **this PR** — harness scenarios

## Test plan
- [x] +5 harness scenarios (all green)
- [x] \`bun test\` green (538 pass, was 533)
- [x] \`bunx tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)