### PR TITLE
feat(telegram-plugin): multi-agent progress card — correlation + renderer + rate-limit + harness (rescued)

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -61,6 +61,19 @@ export interface ProgressDriverConfig {
    * any chat has a running turn. Default 5000. Set to 0 to disable.
    */
   heartbeatMs?: number
+  /**
+   * Multi-agent rate-limit guardrail (design §4.4). Telegram caps edits
+   * at ~20/min/chat. With N parallel sub-agents emitting bursty events
+   * the default 400ms coalesce + 500ms floor can exceed the cap. When
+   * we observe more than `editBudgetThreshold` edits in the trailing
+   * 60s for a chat, the coalesce window expands to `editBudgetCoalesceMs`
+   * until the rate drops back. Heartbeat is also suppressed while the
+   * budget is hot.
+   *
+   * Defaults: threshold=18, coalesce window when hot=3000ms.
+   */
+  editBudgetThreshold?: number
+  editBudgetCoalesceMs?: number
 }
 
 /**
@@ -142,6 +155,27 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       clearInterval(handle)
     })
   const heartbeatMs = config.heartbeatMs ?? 5000
+  const editBudgetThreshold = config.editBudgetThreshold ?? 18
+  const editBudgetCoalesceMs = config.editBudgetCoalesceMs ?? 3000
+  // Per-chat sliding 60s window of recent emit timestamps. When the
+  // window holds more than `editBudgetThreshold` entries we're "hot"
+  // and coalesce more aggressively.
+  const editTimestamps = new Map<string, number[]>()
+  function recordEdit(k: string): void {
+    const arr = editTimestamps.get(k) ?? []
+    arr.push(now())
+    // Drop entries older than 60s.
+    const cutoff = now() - 60_000
+    while (arr.length > 0 && arr[0] < cutoff) arr.shift()
+    editTimestamps.set(k, arr)
+  }
+  function isBudgetHot(k: string): boolean {
+    const arr = editTimestamps.get(k)
+    if (!arr) return false
+    const cutoff = now() - 60_000
+    while (arr.length > 0 && arr[0] < cutoff) arr.shift()
+    return arr.length >= editBudgetThreshold
+  }
 
   const chats = new Map<string, PerChatState>()
   // Track the last enqueued chat so non-enqueue session events (tool_use,
@@ -173,6 +207,11 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       // (rounded to the heartbeat period) advanced.
       for (const [k, cs] of chats) {
         if (cs.state.stage === 'done') continue
+        // Skip heartbeat while the chat is hot — sub-agent bursts are
+        // already producing edits, the elapsed counter is ticking from
+        // those, and an extra heartbeat edit just spends budget. (Design
+        // §4.4: "heartbeat respects budget too".)
+        if (isBudgetHot(k)) continue
         const html = render(cs.state, now())
         const bucket = Math.floor(now() / heartbeatMs)
         const prevBucket = lastHeartbeatBucket.get(k)
@@ -180,6 +219,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         lastHeartbeatBucket.set(k, bucket)
         cs.lastEmittedHtml = html
         cs.lastEmittedAt = now()
+        recordEdit(k)
         config.emit({
           chatId: cs.chatId,
           threadId: cs.threadId,
@@ -208,6 +248,8 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     if (html === chatState.lastEmittedHtml && !forceDone) return
     chatState.lastEmittedHtml = html
     chatState.lastEmittedAt = now()
+    const k = key(chatState.chatId, chatState.threadId)
+    recordEdit(k)
     config.emit({
       chatId: chatState.chatId,
       threadId: chatState.threadId,
@@ -310,6 +352,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           // Drop the chat state so a subsequent turn starts clean.
           chats.delete(k)
           lastHeartbeatBucket.delete(k)
+          editTimestamps.delete(k)
           if (currentChatId === chatId && currentThreadId === threadId) {
             currentChatId = null
             currentThreadId = undefined
@@ -331,8 +374,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       // defer to at least minIntervalMs after the last emit. Also always
       // coalesce bursts — even a burst that runs past minIntervalMs gets
       // at most one flush per coalesce window.
+      //
+      // Multi-agent rate-limit: if the chat has emitted >threshold edits
+      // in the last 60s, expand the coalesce window to
+      // editBudgetCoalesceMs (default 3s) so the Telegram 20/min cap is
+      // never exceeded by sub-agent bursts.
       const sinceLast = now() - chatState.lastEmittedAt
-      const delay = Math.max(coalesceMs, minIntervalMs - sinceLast, 0)
+      const effectiveCoalesce = isBudgetHot(k) ? editBudgetCoalesceMs : coalesceMs
+      const delay = Math.max(effectiveCoalesce, minIntervalMs - sinceLast, 0)
       chatState.pendingTimer = setT(() => {
         // Defensive: if the chat was deleted between schedule and fire
         // (e.g. a turn_end racing with an async boundary added later),

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -272,6 +272,24 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     for (let i = 0; i < a.items.length; i++) {
       if (a.items[i].state !== b.items[i].state) return true
       if (a.items[i].tool !== b.items[i].tool) return true
+      // Multi-agent: spawnedAgentId attached on correlation matters for
+      // the [Main] line's 🤖 vs ✅ glyph (PR 3 renderer).
+      if (a.items[i].spawnedAgentId !== b.items[i].spawnedAgentId) return true
+    }
+    // Multi-agent: any change in sub-agent shape or per-sub-agent state
+    // is user-visible. Cheap O(N) scan; N is the sub-agent count, which
+    // is bounded by how many parallel Agent calls one turn makes (~4–12
+    // in practice).
+    if (a.subAgents.size !== b.subAgents.size) return true
+    for (const [k, sa] of a.subAgents) {
+      const sb = b.subAgents.get(k)
+      if (!sb) return true
+      if (sa.state !== sb.state) return true
+      if (sa.toolCount !== sb.toolCount) return true
+      if (sa.description !== sb.description) return true
+      if (sa.parentToolUseId !== sb.parentToolUseId) return true
+      if (sa.nestedSpawnCount !== sb.nestedSpawnCount) return true
+      if ((sa.currentTool?.toolUseId ?? null) !== (sb.currentTool?.toolUseId ?? null)) return true
     }
     return false
   }

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -45,6 +45,14 @@ export interface ChecklistItem {
   readonly startedAt: number
   /** Unix ms when tool_result arrived. Only set on done/failed. */
   readonly finishedAt?: number
+  /**
+   * Multi-agent: for `Agent`/`Task` tool_use items only, the `agentId`
+   * of the correlated sub-agent. Set when `sub_agent_started` lands and
+   * matches this item's prompt text. Renderer (later PR) uses it to
+   * keep the [Main] line in 🤖 (not ✅) until the parent's tool_result
+   * arrives. Null until correlation succeeds.
+   */
+  readonly spawnedAgentId?: string | null
 }
 
 export type Stage = 'plan' | 'run' | 'done'
@@ -201,11 +209,61 @@ export function reduce(
         state: 'running',
         startedAt: now,
       }
+      // Multi-agent: if this is an Agent/Task tool_use, stage a pending
+      // spawn awaiting the matching sub-agent JSONL. Correlation key is
+      // the prompt text (the sub-agent's first user message contains
+      // exactly this string). Reverse-race: if a sub-agent already
+      // landed as orphan with this prompt text, adopt it now.
+      let pendingAgentSpawns = state.pendingAgentSpawns
+      let subAgents = state.subAgents
+      if (
+        (event.toolName === 'Agent' || event.toolName === 'Task') &&
+        event.toolUseId &&
+        event.input
+      ) {
+        const promptText = String(event.input.prompt ?? '')
+        const description = String(event.input.description ?? '') || promptText.slice(0, 50)
+        const subagentType =
+          typeof event.input.subagent_type === 'string'
+            ? (event.input.subagent_type as string)
+            : undefined
+        // Reverse-race adoption: scan orphan sub-agents (parentToolUseId
+        // null) for a prompt-text match and adopt the FIRST matching one.
+        // FIFO disambiguates duplicate-prompt bursts (rare).
+        let adopted = false
+        for (const [agentId, sa] of subAgents) {
+          if (sa.parentToolUseId == null && sa.firstPromptText === promptText) {
+            const next = new Map(subAgents)
+            next.set(agentId, {
+              ...sa,
+              parentToolUseId: event.toolUseId,
+              description,
+              subagentType,
+            })
+            subAgents = next
+            adopted = true
+            break
+          }
+        }
+        if (!adopted) {
+          const nextPending = new Map(pendingAgentSpawns)
+          nextPending.set(event.toolUseId, {
+            parentToolUseId: event.toolUseId,
+            description,
+            subagentType,
+            promptText,
+            startedAt: now,
+          })
+          pendingAgentSpawns = nextPending
+        }
+      }
       return {
         ...state,
         items: [...state.items, nextItem],
         stage: 'run',
         thinking: false,
+        pendingAgentSpawns,
+        subAgents,
       }
     }
 
@@ -231,7 +289,128 @@ export function reduce(
       const items = state.items.slice()
       const nextState: ItemState = event.isError === true ? 'failed' : 'done'
       items[idx] = { ...items[idx], state: nextState, finishedAt: now }
-      return { ...state, items }
+      // Multi-agent: a parent Agent/Task tool_result is the authoritative
+      // close-out for its sub-agent. Find any sub-agent linked to this
+      // toolUseId (via parentToolUseId) and finalize it. Also clear any
+      // matching pendingAgentSpawn (sub-agent JSONL never appeared).
+      let subAgents = state.subAgents
+      let pendingAgentSpawns = state.pendingAgentSpawns
+      if (event.toolUseId) {
+        for (const [agentId, sa] of subAgents) {
+          if (sa.parentToolUseId === event.toolUseId) {
+            const next = new Map(subAgents)
+            next.set(agentId, { ...sa, state: nextState, finishedAt: now })
+            subAgents = next
+            break
+          }
+        }
+        if (pendingAgentSpawns.has(event.toolUseId)) {
+          const next = new Map(pendingAgentSpawns)
+          next.delete(event.toolUseId)
+          pendingAgentSpawns = next
+        }
+      }
+      return { ...state, items, subAgents, pendingAgentSpawns }
+    }
+
+    case 'sub_agent_started': {
+      if (state.turnStartedAt === 0) return state
+      // Already known? (Defensive — re-attach can re-emit.)
+      if (state.subAgents.has(event.agentId)) return state
+      // Try to correlate by prompt-text against pendingAgentSpawns. On
+      // hit: move pending → subAgents, link the matching [Main]
+      // ChecklistItem via spawnedAgentId, and consume the pending entry.
+      // On miss: register as orphan; the parent's tool_use may arrive
+      // later (reverse race) and adopt via the tool_use case.
+      let parentToolUseId: string | null = null
+      let description = '(uncorrelated)'
+      let subagentType: string | undefined
+      let pendingAgentSpawns = state.pendingAgentSpawns
+      let items = state.items
+      for (const [parentId, pending] of pendingAgentSpawns) {
+        if (pending.promptText === event.firstPromptText) {
+          parentToolUseId = parentId
+          description = pending.description
+          subagentType = pending.subagentType
+          const nextPending = new Map(pendingAgentSpawns)
+          nextPending.delete(parentId)
+          pendingAgentSpawns = nextPending
+          // Link the [Main] checklist item back so renderer can keep
+          // its 🤖 state consistent.
+          items = items.map((it) =>
+            it.toolUseId === parentId
+              ? { ...it, spawnedAgentId: event.agentId }
+              : it,
+          )
+          break
+        }
+      }
+      const sub: SubAgentState = {
+        agentId: event.agentId,
+        description,
+        subagentType: subagentType ?? event.subagentType,
+        parentToolUseId,
+        state: 'running',
+        startedAt: now,
+        toolCount: 0,
+        firstPromptText: event.firstPromptText,
+        nestedSpawnCount: 0,
+      }
+      const subAgents = new Map(state.subAgents)
+      subAgents.set(event.agentId, sub)
+      return { ...state, subAgents, pendingAgentSpawns, items }
+    }
+
+    case 'sub_agent_tool_use': {
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      const next = new Map(state.subAgents)
+      next.set(event.agentId, {
+        ...sa,
+        toolCount: sa.toolCount + 1,
+        currentTool: event.toolUseId
+          ? {
+              tool: event.toolName,
+              label: toolLabel(event.toolName, event.input),
+              toolUseId: event.toolUseId,
+              startedAt: now,
+            }
+          : sa.currentTool,
+      })
+      return { ...state, subAgents: next }
+    }
+
+    case 'sub_agent_tool_result': {
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      // Per design §3.3: per-tool errors don't fail the agent; only the
+      // parent's tool_result does. We just clear currentTool if it
+      // matches.
+      if (sa.currentTool && sa.currentTool.toolUseId === event.toolUseId) {
+        const next = new Map(state.subAgents)
+        next.set(event.agentId, { ...sa, currentTool: undefined })
+        return { ...state, subAgents: next }
+      }
+      return state
+    }
+
+    case 'sub_agent_turn_end': {
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      // Tentative close: parent's tool_result is still authoritative.
+      // If it later arrives with isError=true, the tool_result case
+      // overrides this 'done' with 'failed'.
+      const next = new Map(state.subAgents)
+      next.set(event.agentId, { ...sa, state: 'done', finishedAt: now })
+      return { ...state, subAgents: next }
+    }
+
+    case 'sub_agent_nested_spawn': {
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      const next = new Map(state.subAgents)
+      next.set(event.agentId, { ...sa, nestedSpawnCount: sa.nestedSpawnCount + 1 })
+      return { ...state, subAgents: next }
     }
 
     case 'turn_end': {
@@ -240,7 +419,20 @@ export function reduce(
       const items = state.items.map((it) =>
         it.state === 'running' ? { ...it, state: 'done' as const, finishedAt: now } : it,
       )
-      return { ...state, items, stage: 'done', thinking: false }
+      // Close any still-running sub-agents + clear pending spawns that
+      // never correlated.
+      const subAgents = new Map<string, SubAgentState>()
+      for (const [k, sa] of state.subAgents) {
+        subAgents.set(k, sa.state === 'running' ? { ...sa, state: 'done', finishedAt: now } : sa)
+      }
+      return {
+        ...state,
+        items,
+        subAgents,
+        pendingAgentSpawns: new Map(),
+        stage: 'done',
+        thinking: false,
+      }
     }
 
     case 'dequeue':

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -538,6 +538,11 @@ export function applyVisibleCap(
 /**
  * Render the current state to Telegram HTML. `now` is the wall-clock time
  * used for elapsed-time calculations so the render is deterministic in tests.
+ *
+ * Multi-agent: when `PROGRESS_CARD_MULTI_AGENT=1` AND there is any sub-agent
+ * activity (subAgents non-empty OR pendingAgentSpawns non-empty), the card
+ * splits into [Main] / [Sub-agents] sections. Otherwise the layout is
+ * byte-identical to the legacy single-section card.
  */
 export function render(state: ProgressCardState, now: number): string {
   if (state.turnStartedAt === 0) {
@@ -561,6 +566,16 @@ export function render(state: ProgressCardState, now: number): string {
   // Thin visual separator so the bullets below don't blur into the header.
   lines.push('─ ─ ─')
 
+  const multiAgentActive =
+    isMultiAgentEnabled() &&
+    (state.subAgents.size > 0 || state.pendingAgentSpawns.size > 0)
+
+  // [Main] header only when multi-agent rendering is active. Keeps the
+  // single-agent case visually unchanged (no header, just the checklist).
+  if (multiAgentActive) {
+    lines.push(`[Main · ${state.items.length} tools]`)
+  }
+
   // Checklist — preserve insertion order; running items show elapsed time.
   // The old static "🤔 Plan → 🔧 Run → ✅ Done" phase line is gone: users
   // asked for a live per-tool-call checklist instead. The header banner
@@ -571,23 +586,18 @@ export function render(state: ProgressCardState, now: number): string {
     lines.push(`  … (+${visible.overflowCount} more earlier steps)`)
   }
   for (const item of visible.items) {
-    const emoji = STATE_EMOJI[item.state]
-    if (item.state === 'running') {
-      const dur = formatDuration(now - item.startedAt)
-      lines.push(`  ${emoji} ${renderItemCore(item.tool, item.label, /*bold*/ true)} <i>(${dur})</i>`)
-    } else if ((item.state === 'done' || item.state === 'failed') && item.finishedAt != null) {
-      if (item.kind === 'rollup') {
-        lines.push(`  ${emoji} ${escapeHtml(item.tool)} <i>×${item.count}</i>`)
-      } else {
-        // Short tools don't need duration — they're ~always sub-second.
-        const dur = formatDuration(item.finishedAt - item.startedAt)
-        const needsDuration = item.finishedAt - item.startedAt >= 1000
-        lines.push(
-          `  ${emoji} ${renderItemCore(item.tool, item.label)}${needsDuration ? ` <i>(${dur})</i>` : ''}`,
-        )
+    lines.push(renderMainItem(item, now, multiAgentActive, state.subAgents))
+  }
+
+  // [Sub-agents] section
+  if (multiAgentActive && state.subAgents.size > 0) {
+    lines.push('') // blank separator
+    const counts = countSubAgentStates(state.subAgents)
+    lines.push(`[Sub-agents · ${formatSubAgentCounts(counts)}]`)
+    for (const sa of sortSubAgentsChrono(state.subAgents)) {
+      for (const l of renderSubAgent(sa, now, state.stage === 'done')) {
+        lines.push(l)
       }
-    } else {
-      lines.push(`  ${emoji} ${renderItemCore(item.tool, item.label)}`)
     }
   }
 
@@ -598,6 +608,142 @@ export function render(state: ProgressCardState, now: number): string {
   }
 
   return lines.join('\n')
+}
+
+/**
+ * Render one [Main]-section line. Encapsulates the existing per-state
+ * branches (running/rollup/done) so the main render() loop reads cleanly.
+ *
+ * Multi-agent twist (Ken locked-in #4): an `Agent`/`Task` item with a
+ * correlated, still-running sub-agent stays in the 🤖 emoji even if its
+ * own state field already happens to be 'running' — and we DON'T flip it
+ * to ✅ on a tentative `sub_agent_turn_end`. Only the parent's own
+ * tool_result (which mutates `item.state` to 'done'/'failed') flips it.
+ */
+function renderMainItem(
+  item: RolledItem,
+  now: number,
+  multiAgentActive: boolean,
+  subAgents: ReadonlyMap<string, SubAgentState>,
+): string {
+  const isAgent = item.tool === 'Agent' || item.tool === 'Task'
+  const indent = multiAgentActive ? '  ' : '  '
+
+  if (isAgent && item.state === 'running' && multiAgentActive) {
+    // Hold the 🤖 emoji while the sub-agent (if correlated) is alive.
+    // Show elapsed since the parent's tool_use fired.
+    const dur = formatDuration(now - item.startedAt)
+    return `${indent}🤖 ${renderItemCore(item.tool, item.label, /*bold*/ true)} <i>(${dur})</i>`
+  }
+
+  const emoji = STATE_EMOJI[item.state]
+  if (item.state === 'running') {
+    const dur = formatDuration(now - item.startedAt)
+    return `${indent}${emoji} ${renderItemCore(item.tool, item.label, /*bold*/ true)} <i>(${dur})</i>`
+  }
+  if ((item.state === 'done' || item.state === 'failed') && item.finishedAt != null) {
+    if (item.kind === 'rollup') {
+      return `${indent}${emoji} ${escapeHtml(item.tool)} <i>×${item.count}</i>`
+    }
+    const dur = formatDuration(item.finishedAt - item.startedAt)
+    const needsDuration = item.finishedAt - item.startedAt >= 1000
+    // For Agent/Task in multi-agent mode, prefix emoji is the regular
+    // ✅/❌ — design §1.4 shows "✅ Agent: …" on the final card. The
+    // sub-agent's own state lives in the [Sub-agents] section.
+    return `${indent}${emoji} ${renderItemCore(item.tool, item.label)}${needsDuration ? ` <i>(${dur})</i>` : ''}`
+  }
+  // pending fallback
+  void subAgents
+  return `${indent}${emoji} ${renderItemCore(item.tool, item.label)}`
+}
+
+/**
+ * Sort sub-agents by chronological start time — oldest first (Ken
+ * locked-in #1). Stable across renders so rows don't shuffle as states
+ * transition. We deliberately do NOT bucket by state (failed-first /
+ * done-first) because state changes mid-turn would cause visible
+ * reorder.
+ */
+function sortSubAgentsChrono(
+  subAgents: ReadonlyMap<string, SubAgentState>,
+): SubAgentState[] {
+  return Array.from(subAgents.values()).sort((a, b) => a.startedAt - b.startedAt)
+}
+
+interface SubAgentCounts {
+  running: number
+  done: number
+  failed: number
+}
+
+function countSubAgentStates(
+  subAgents: ReadonlyMap<string, SubAgentState>,
+): SubAgentCounts {
+  let running = 0
+  let done = 0
+  let failed = 0
+  for (const sa of subAgents.values()) {
+    if (sa.state === 'running') running++
+    else if (sa.state === 'done') done++
+    else if (sa.state === 'failed') failed++
+  }
+  return { running, done, failed }
+}
+
+function formatSubAgentCounts(c: SubAgentCounts): string {
+  const parts: string[] = []
+  if (c.running > 0) parts.push(`${c.running} running`)
+  if (c.done > 0) parts.push(`${c.done} done`)
+  if (c.failed > 0) parts.push(`${c.failed} failed`)
+  return parts.length === 0 ? '0' : parts.join(', ')
+}
+
+/**
+ * Render a sub-agent block. Two lines while running (header + current
+ * activity), one line when done/failed (compact summary).
+ *
+ * Header line includes:
+ *  - state emoji (🤖 running, ✅ done, ❌ failed)
+ *  - description (or '(uncorrelated)' for orphans)
+ *  - subagent_type after a ` · ` separator (Ken locked-in #2 — always show)
+ *  - elapsed time
+ *  - `(spawned N)` suffix when nestedSpawnCount > 0 (Ken locked-in #3)
+ *
+ * The `forceCollapse` arg is set on `turn_end` (Ken locked-in #5) so the
+ * archived card never carries the running two-line shape.
+ */
+function renderSubAgent(
+  sa: SubAgentState,
+  now: number,
+  forceCollapse: boolean,
+): string[] {
+  const desc = sa.description || '(uncorrelated)'
+  const typeSuffix = sa.subagentType ? ` · ${escapeHtml(sa.subagentType)}` : ''
+  const spawnedSuffix = sa.nestedSpawnCount > 0
+    ? ` <i>(spawned ${sa.nestedSpawnCount})</i>`
+    : ''
+
+  if (sa.state !== 'running' || forceCollapse) {
+    const emoji = sa.state === 'failed' ? '❌' : '✅'
+    const end = sa.finishedAt ?? now
+    const dur = formatDuration(end - sa.startedAt)
+    return [
+      `  ${emoji} ${escapeHtml(truncate(desc, 50))}${typeSuffix} · ${dur} · ${sa.toolCount} tools${spawnedSuffix}`,
+    ]
+  }
+
+  // Running: two-line block.
+  const elapsed = formatDuration(now - sa.startedAt)
+  const headerLine = `  🤖 <b>${escapeHtml(truncate(desc, 50))}</b>${typeSuffix} · ⏱ ${elapsed}${spawnedSuffix}`
+  if (sa.currentTool) {
+    const cur = sa.currentTool
+    const curDur = formatDuration(now - cur.startedAt)
+    return [
+      headerLine,
+      `     └ 🔧 ${renderItemCore(cur.tool, cur.label)} <i>(${curDur})</i> · ${sa.toolCount} tools`,
+    ]
+  }
+  return [headerLine, `     └ <i>(idle)</i> · ${sa.toolCount} tools`]
 }
 
 /**

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -294,20 +294,22 @@ export function projectSubagentLine(
       const ct = c.type as string | undefined
       if (ct === 'tool_use') {
         const name = (c.name as string | undefined) ?? ''
-        // A nested Agent/Task call inside a sub-agent: count it as a
-        // nested spawn so the parent sub-agent line shows (spawned N),
-        // but ALSO emit it as a regular tool_use for the sub-agent's
-        // own tool count (sub-agent A's own Agent call is still a tool
-        // it ran — chrono ordering needs to see it).
-        events.push({
-          kind: 'sub_agent_tool_use',
-          agentId,
-          toolUseId: (c.id as string | undefined) ?? null,
-          toolName: name,
-          input: (c.input as Record<string, unknown> | undefined) ?? undefined,
-        })
+        // Nested Agent/Task call inside a sub-agent: track ONLY as a
+        // nested_spawn count (renders as "(spawned N)" suffix on the
+        // parent sub-agent line). Per design §5.5 we do NOT expose
+        // sub-sub-agent activity as the parent sub-agent's currentTool —
+        // that would surface the sub-sub-agent's description and break
+        // the "no recursion in rendering" rule.
         if (name === 'Agent' || name === 'Task') {
           events.push({ kind: 'sub_agent_nested_spawn', agentId })
+        } else {
+          events.push({
+            kind: 'sub_agent_tool_use',
+            agentId,
+            toolUseId: (c.id as string | undefined) ?? null,
+            toolName: name,
+            input: (c.input as Record<string, unknown> | undefined) ?? undefined,
+          })
         }
       }
     }

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -33,7 +33,8 @@ import {
   type FSWatcher,
 } from 'fs'
 import { homedir } from 'os'
-import { join } from 'path'
+import { basename, join } from 'path'
+import { isMultiAgentEnabled } from './progress-card.js'
 
 /** Match Claude Code's cli.js VX() function. */
 export function sanitizeCwdToProjectName(cwd: string): string {
@@ -88,6 +89,14 @@ export type SessionEvent =
   | { kind: 'text'; text: string }
   | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean }
   | { kind: 'turn_end'; durationMs: number }
+  // Multi-agent: sub-agent-scoped events. agentId is the sub-agent JSONL
+  // filename stem (e.g. "aac6f1…"). Routed through the same ingest path
+  // as parent events; the reducer fans them out to per-sub-agent state.
+  | { kind: 'sub_agent_started'; agentId: string; firstPromptText: string; subagentType?: string }
+  | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown> }
+  | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean }
+  | { kind: 'sub_agent_turn_end'; agentId: string }
+  | { kind: 'sub_agent_nested_spawn'; agentId: string }
 
 /**
  * Parse the inbound channel XML wrapper to pull out chat_id, message_id,
@@ -197,6 +206,116 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     return [
       { kind: 'turn_end', durationMs: (obj.durationMs as number | undefined) ?? 0 },
     ]
+  }
+
+  return []
+}
+
+/**
+ * Project a single line from a sub-agent JSONL into SessionEvent(s).
+ *
+ * Sub-agent JSONLs (under `<sessionId>/subagents/agent-<agentId>.jsonl`)
+ * use the same line shapes as the parent transcript but with `isSidechain: true`
+ * and an `agentId` field on every line. The first `type=user` message in
+ * the file holds the full prompt text the parent passed in via the
+ * `Agent` tool — that's our correlation key.
+ *
+ * Caller passes the `agentId` extracted from the filename and a stateful
+ * `hasEmittedStart` flag (one per file) so the very first user message
+ * fires `sub_agent_started` exactly once. Subsequent user messages carry
+ * tool_results.
+ *
+ * Sub-agents that themselves spawn more Agent/Task calls fire a
+ * `sub_agent_nested_spawn` event so the parent sub-agent line can render
+ * `(spawned N)`. We do NOT expose nested sub-agent activity as top-level
+ * rows — the design doc explicitly punts on recursion (§5.5).
+ */
+export function projectSubagentLine(
+  line: string,
+  agentId: string,
+  state: { hasEmittedStart: boolean },
+): SessionEvent[] {
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(line)
+  } catch {
+    return []
+  }
+  const type = obj.type as string | undefined
+  if (!type) return []
+
+  if (type === 'user') {
+    const message = obj.message as Record<string, unknown> | undefined
+    const content = message?.content
+    // First user message: the prompt body. Claude Code writes it as a
+    // string for the kickoff message, then as content arrays of
+    // tool_results for subsequent user messages.
+    if (!state.hasEmittedStart) {
+      state.hasEmittedStart = true
+      let promptText = ''
+      if (typeof content === 'string') {
+        promptText = content
+      } else if (Array.isArray(content)) {
+        // Some shapes wrap the prompt in a [{type: 'text', text: '…'}]
+        // block. Handle defensively.
+        for (const c of content) {
+          if (typeof c === 'object' && c != null && (c as Record<string, unknown>).type === 'text') {
+            promptText = String((c as Record<string, unknown>).text ?? '')
+            break
+          }
+        }
+      }
+      return [{ kind: 'sub_agent_started', agentId, firstPromptText: promptText }]
+    }
+    // Subsequent user messages = tool_results
+    if (!Array.isArray(content)) return []
+    const events: SessionEvent[] = []
+    for (const c of content) {
+      if (typeof c !== 'object' || c == null) continue
+      const cc = c as Record<string, unknown>
+      if (cc.type === 'tool_result') {
+        events.push({
+          kind: 'sub_agent_tool_result',
+          agentId,
+          toolUseId: (cc.tool_use_id as string | undefined) ?? '',
+          isError: cc.is_error === true ? true : undefined,
+        })
+      }
+    }
+    return events
+  }
+
+  if (type === 'assistant') {
+    const message = obj.message as Record<string, unknown> | undefined
+    const content = message?.content as Array<Record<string, unknown>> | undefined
+    if (!Array.isArray(content)) return []
+    const events: SessionEvent[] = []
+    for (const c of content) {
+      const ct = c.type as string | undefined
+      if (ct === 'tool_use') {
+        const name = (c.name as string | undefined) ?? ''
+        // A nested Agent/Task call inside a sub-agent: count it as a
+        // nested spawn so the parent sub-agent line shows (spawned N),
+        // but ALSO emit it as a regular tool_use for the sub-agent's
+        // own tool count (sub-agent A's own Agent call is still a tool
+        // it ran — chrono ordering needs to see it).
+        events.push({
+          kind: 'sub_agent_tool_use',
+          agentId,
+          toolUseId: (c.id as string | undefined) ?? null,
+          toolName: name,
+          input: (c.input as Record<string, unknown> | undefined) ?? undefined,
+        })
+        if (name === 'Agent' || name === 'Task') {
+          events.push({ kind: 'sub_agent_nested_spawn', agentId })
+        }
+      }
+    }
+    return events
+  }
+
+  if (type === 'system' && obj.subtype === 'turn_duration') {
+    return [{ kind: 'sub_agent_turn_end', agentId }]
   }
 
   return []
@@ -341,6 +460,126 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     }
   }
 
+  // ─── Sub-agent JSONL tailing (multi-agent path, gated by feature flag) ──
+  //
+  // Each sub-agent gets its own per-file tailer keyed by absolute path.
+  // We poll the `<sessionId>/subagents/` directory on every rescan (cheap,
+  // a few stat calls) so newly-created sub-agent JSONLs are picked up
+  // even when fs.watch on the parent dir is unreliable. Once attached,
+  // a per-file watch + cursor handles incremental reads exactly the way
+  // the parent tail does — and exactly the same per-file cursor map
+  // pattern from PR #25 protects against re-attach truncation.
+  const multiAgent = isMultiAgentEnabled()
+
+  interface SubTail {
+    agentId: string
+    file: string
+    cursor: number
+    pendingPartial: string
+    hasEmittedStart: boolean
+    watcher: FSWatcher | null
+  }
+  const subTails = new Map<string, SubTail>() // keyed by absolute file path
+
+  function readSub(t: SubTail): void {
+    if (stopped) return
+    try {
+      const stat = statSync(t.file)
+      if (stat.size < t.cursor) {
+        t.cursor = 0
+        t.pendingPartial = ''
+      }
+      if (stat.size === t.cursor) return
+      const buf = Buffer.alloc(stat.size - t.cursor)
+      const fd = openSync(t.file, 'r')
+      try {
+        readSync(fd, buf, 0, buf.length, t.cursor)
+      } finally {
+        closeSync(fd)
+      }
+      t.cursor = stat.size
+      const text = t.pendingPartial + buf.toString('utf-8')
+      const lines = text.split('\n')
+      t.pendingPartial = lines.pop() ?? ''
+      const startState = { hasEmittedStart: t.hasEmittedStart }
+      for (const line of lines) {
+        if (!line) continue
+        const events = projectSubagentLine(line, t.agentId, startState)
+        for (const ev of events) {
+          try {
+            onEvent(ev)
+          } catch (err) {
+            log?.(`session-tail: sub onEvent threw: ${(err as Error).message}`)
+          }
+        }
+      }
+      t.hasEmittedStart = startState.hasEmittedStart
+    } catch (err) {
+      log?.(`session-tail: sub read failed: ${(err as Error).message}`)
+    }
+  }
+
+  function attachSub(file: string, agentId: string): void {
+    if (subTails.has(file)) return
+    let cursor = 0
+    try {
+      cursor = statSync(file).size
+    } catch { /* ignore */ }
+    // Sub-agent JSONLs are typically created and immediately written; we
+    // start at byte 0 so we DON'T miss the first user-message line that
+    // carries the prompt text needed for correlation. This differs from
+    // the parent tail which seeks to end (parent has long history).
+    const t: SubTail = {
+      agentId,
+      file,
+      cursor: 0, // intentionally 0: read from start to capture prompt
+      pendingPartial: '',
+      hasEmittedStart: false,
+      watcher: null,
+    }
+    void cursor
+    try {
+      t.watcher = watch(file, () => readSub(t))
+    } catch (err) {
+      log?.(`session-tail: sub fs.watch failed (${(err as Error).message})`)
+    }
+    subTails.set(file, t)
+    log?.(`session-tail: attached sub ${agentId} (${file})`)
+    readSub(t)
+  }
+
+  /**
+   * Sub-agent dir lives next to the parent JSONL: if the parent file is
+   * `<projectsDir>/<sessionId>.jsonl`, sub-agents live under
+   * `<projectsDir>/<sessionId>/subagents/agent-<agentId>.jsonl`.
+   *
+   * Claude Code 2.1.x has been observed to use this layout. If a future
+   * release renames `agent-*.jsonl`, the glob check below is the only
+   * place to update.
+   */
+  function rescanSubagents(): void {
+    if (!multiAgent) return
+    if (!currentFile) return
+    const sessionId = basename(currentFile, '.jsonl')
+    const subDir = join(projectsDir, sessionId, 'subagents')
+    if (!existsSync(subDir)) return
+    let entries: string[]
+    try {
+      entries = readdirSync(subDir)
+    } catch { return }
+    for (const e of entries) {
+      if (!e.startsWith('agent-') || !e.endsWith('.jsonl')) continue
+      const agentId = e.slice('agent-'.length, -'.jsonl'.length)
+      const file = join(subDir, e)
+      if (!subTails.has(file)) {
+        attachSub(file, agentId)
+      } else {
+        // Already attached — defensive read in case fs.watch missed.
+        readSub(subTails.get(file)!)
+      }
+    }
+  }
+
   function rescan(): void {
     if (stopped) return
     const file = findActiveSessionFile(projectsDir)
@@ -350,6 +589,7 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     }
     // Always read in case fs.watch missed an event (common on WSL/network mounts)
     readNew()
+    rescanSubagents()
   }
 
   // Initial pass
@@ -363,6 +603,13 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
         try { watcher.close() } catch { /* ignore */ }
         watcher = null
       }
+      for (const t of subTails.values()) {
+        if (t.watcher) {
+          try { t.watcher.close() } catch { /* ignore */ }
+          t.watcher = null
+        }
+      }
+      subTails.clear()
       if (pollTimer) {
         clearInterval(pollTimer)
         pollTimer = null

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -421,3 +421,78 @@ describe('summariseTurn', () => {
     expect(summariseTurn(s, 2000)).toBe('1 tool, 1s')
   })
 })
+
+describe('progress-card driver — multi-agent rate limit', () => {
+  it('expands coalesce window once edit budget is hot (>18 in 60s)', () => {
+    // Use a small threshold so we can exercise the path without
+    // simulating 18 distinct events. editBudgetCoalesceMs=2000, threshold=3.
+    let now = 1000
+    const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+    let nextRef = 0
+    const emits: Array<{ chatId: string; html: string; done: boolean }> = []
+    const driver = createProgressDriver({
+      emit: (a) => emits.push({ chatId: a.chatId, html: a.html, done: a.done }),
+      minIntervalMs: 100,
+      coalesceMs: 100,
+      heartbeatMs: 0,
+      editBudgetThreshold: 3,
+      editBudgetCoalesceMs: 2000,
+      now: () => now,
+      setTimeout: (fn, ms) => {
+        const ref = nextRef++
+        timers.push({ fireAt: now + ms, fn, ref })
+        return { ref }
+      },
+      clearTimeout: (h) => {
+        const t = (h as { ref: number }).ref
+        const i = timers.findIndex((x) => x.ref === t)
+        if (i !== -1) timers.splice(i, 1)
+      },
+      setInterval: (fn, ms) => {
+        const ref = nextRef++
+        timers.push({ fireAt: now + ms, fn, ref, repeat: ms })
+        return { ref }
+      },
+      clearInterval: (h) => {
+        const t = (h as { ref: number }).ref
+        const i = timers.findIndex((x) => x.ref === t)
+        if (i !== -1) timers.splice(i, 1)
+      },
+    })
+    const advance = (ms: number): void => {
+      now += ms
+      for (;;) {
+        timers.sort((a, b) => a.fireAt - b.fireAt)
+        const t = timers[0]
+        if (!t || t.fireAt > now) break
+        if (t.repeat != null) { t.fireAt += t.repeat; t.fn() } else { timers.shift(); t.fn() }
+      }
+    }
+
+    // Fire 4 distinct visible-state events 200ms apart — each forces an
+    // emit (well past the 100ms coalesce). After 3 emits we go hot.
+    driver.ingest(
+      { kind: 'enqueue', chatId: 'c', messageId: '1', threadId: null, rawContent: '<channel chat_id="c">go</channel>' },
+      null,
+    )
+    expect(emits.length).toBe(1) // enqueue is immediate
+
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 'a', input: { file_path: '/x' } }, 'c')
+    advance(200)
+    driver.ingest({ kind: 'tool_result', toolUseId: 'a', toolName: 'Read' }, 'c')
+    advance(200)
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 'b', input: { file_path: '/y' } }, 'c')
+    advance(200)
+    // Should have ~4 emits by now (enqueue + 3 visible updates). Now hot.
+    const emitsBeforeHot = emits.length
+    expect(emitsBeforeHot).toBeGreaterThanOrEqual(3)
+
+    // Schedule another visible event. With budget hot, coalesce expands
+    // to 2000ms so a 500ms wait must NOT fire it.
+    driver.ingest({ kind: 'tool_result', toolUseId: 'b', toolName: 'Read' }, 'c')
+    advance(500)
+    expect(emits.length).toBe(emitsBeforeHot) // suppressed by hot coalesce
+    advance(2000)
+    expect(emits.length).toBe(emitsBeforeHot + 1) // finally fires
+  })
+})

--- a/telegram-plugin/tests/progress-card-harness.test.ts
+++ b/telegram-plugin/tests/progress-card-harness.test.ts
@@ -371,3 +371,295 @@ describe('progress-card integration harness', () => {
     driver.dispose?.()
   })
 })
+
+// ─── Multi-agent integration scenarios (design doc §5) ───────────────────
+//
+// These mirror §5.1–§5.7 of telegram-plugin/docs/multi-agent-card-design.md.
+// Each scenario exercises the full pipeline (tail + correlation + render)
+// with PROGRESS_CARD_MULTI_AGENT=1. §5.8 (rate-limit budget) is covered
+// by the driver unit test instead — it needs a synthetic clock.
+//
+// The harness materializes a `<sessionId>/subagents/agent-<id>.jsonl`
+// file alongside the parent JSONL so the new tail subdir watcher picks
+// it up.
+
+const subAgentUserLine = (promptText: string): string =>
+  JSON.stringify({
+    isSidechain: true,
+    type: 'user',
+    message: { role: 'user', content: promptText },
+  }) + '\n'
+
+const subAgentToolUseLine = (toolUseId: string, name: string, input: Record<string, unknown>): string =>
+  JSON.stringify({
+    isSidechain: true,
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id: toolUseId, name, input }] },
+  }) + '\n'
+
+const subAgentToolResultLine = (toolUseId: string, isError = false): string =>
+  JSON.stringify({
+    isSidechain: true,
+    type: 'user',
+    message: { content: [{ type: 'tool_result', tool_use_id: toolUseId, is_error: isError }] },
+  }) + '\n'
+
+const subAgentTurnEndLine = (): string =>
+  JSON.stringify({ isSidechain: true, type: 'system', subtype: 'turn_duration', durationMs: 1 }) + '\n'
+
+const parentAgentToolUseLine = (toolUseId: string, description: string, prompt: string, subagentType = 'researcher'): string =>
+  JSON.stringify({
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          id: toolUseId,
+          name: 'Agent',
+          input: { subagent_type: subagentType, description, prompt },
+        },
+      ],
+    },
+  }) + '\n'
+
+function mkSubagentJsonl(projectsDir: string, sessionStem: string, agentId: string): string {
+  const dir = join(projectsDir, sessionStem, 'subagents')
+  mkdirSync(dir, { recursive: true })
+  const file = join(dir, `agent-${agentId}.jsonl`)
+  writeFileSync(file, '')
+  return file
+}
+
+describe('progress-card multi-agent harness', () => {
+  const FLAG = 'PROGRESS_CARD_MULTI_AGENT'
+  function withFlag<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = process.env[FLAG]
+    process.env[FLAG] = '1'
+    return fn().finally(() => {
+      if (prev != null) process.env[FLAG] = prev
+      else delete process.env[FLAG]
+    })
+  }
+
+  it('5.1 — 4 parallel sub-agents, all correlate', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit,
+        coalesceMs: 20,
+        minIntervalMs: 20,
+        heartbeatMs: 0,
+      })
+      const sessionStem = 'session-A'
+      const parent = join(projectsDir, `${sessionStem}.jsonl`)
+      writeFileSync(parent, '')
+
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'fan out 4 investigators'))
+        for (let i = 1; i <= 4; i++) {
+          appendFileSync(parent, parentAgentToolUseLine(`toolu_p${i}`, `task ${i}`, `PROMPT-${i}`))
+        }
+        await wait(150)
+
+        // Pre-correlation: [Main] shows Agent lines but no [Sub-agents] block
+        const preHtml = bot.edits[bot.edits.length - 1].html
+        expect(preHtml).toContain('[Main')
+        expect(preHtml).toContain('task 1')
+        expect(preHtml).toContain('task 4')
+        expect(preHtml).not.toContain('[Sub-agents')
+
+        // Now create 4 sub-agent JSONLs in random-ish order with matching prompts
+        const order = [3, 1, 4, 2]
+        for (const i of order) {
+          const file = mkSubagentJsonl(projectsDir, sessionStem, `aid${i}`)
+          appendFileSync(file, subAgentUserLine(`PROMPT-${i}`))
+        }
+        await wait(200)
+
+        const html = bot.edits[bot.edits.length - 1].html
+        expect(html).toContain('[Sub-agents · 4 running]')
+        for (let i = 1; i <= 4; i++) {
+          expect(html).toContain(`task ${i}`)
+        }
+
+        // Each sub-agent emits a Read tool_use
+        for (let i = 1; i <= 4; i++) {
+          const file = join(projectsDir, sessionStem, 'subagents', `agent-aid${i}.jsonl`)
+          appendFileSync(file, subAgentToolUseLine(`toolu_s${i}`, 'Read', { file_path: `/f${i}` }))
+        }
+        await wait(200)
+        const midHtml = bot.edits[bot.edits.length - 1].html
+        expect(midHtml).toContain('└ 🔧')
+
+        // Parent tool_results for all 4
+        for (let i = 1; i <= 4; i++) {
+          appendFileSync(parent, toolResultLine(`toolu_p${i}`))
+        }
+        appendFileSync(parent, turnEndLine())
+        await wait(250)
+
+        const finalHtml = bot.edits[bot.edits.length - 1].html
+        expect(finalHtml).toMatch(/\[Sub-agents · 4 done\]/)
+        const doneEdits = bot.edits.filter((e) => e.done)
+        expect(doneEdits.length).toBeGreaterThanOrEqual(1)
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+
+  it('5.2 — sub-agent finishes before parent tool_result (early ✅, then isError flips ❌)', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit, coalesceMs: 20, minIntervalMs: 20, heartbeatMs: 0,
+      })
+      const stem = 'session-B'
+      const parent = join(projectsDir, `${stem}.jsonl`)
+      writeFileSync(parent, '')
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'one sub'))
+        appendFileSync(parent, parentAgentToolUseLine('toolu_p1', 'investigate', 'PA'))
+        const sub = mkSubagentJsonl(projectsDir, stem, 'aidX')
+        appendFileSync(sub, subAgentUserLine('PA'))
+        appendFileSync(sub, subAgentTurnEndLine())
+        await wait(200)
+        const earlyHtml = bot.edits[bot.edits.length - 1].html
+        // Tentative ✅ for the sub-agent on early turn_end
+        expect(earlyHtml).toMatch(/✅ investigate/)
+        // Parent tool_result with isError=true overrides → ❌
+        appendFileSync(parent, toolResultLine('toolu_p1', true))
+        appendFileSync(parent, turnEndLine())
+        await wait(250)
+        const finalHtml = bot.edits[bot.edits.length - 1].html
+        expect(finalHtml).toMatch(/❌ investigate/)
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+
+  it('5.3 — sub-agent JSONL appears AFTER parent tool_use (forward race)', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit, coalesceMs: 20, minIntervalMs: 20, heartbeatMs: 0,
+      })
+      const stem = 'session-C'
+      const parent = join(projectsDir, `${stem}.jsonl`)
+      writeFileSync(parent, '')
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'race fwd'))
+        appendFileSync(parent, parentAgentToolUseLine('toolu_p1', 'thing', 'PROMPT-X'))
+        await wait(120)
+        const before = bot.edits[bot.edits.length - 1].html
+        expect(before).not.toContain('[Sub-agents')
+        // Now create the JSONL
+        const sub = mkSubagentJsonl(projectsDir, stem, 'aidA')
+        appendFileSync(sub, subAgentUserLine('PROMPT-X'))
+        await wait(200)
+        const after = bot.edits[bot.edits.length - 1].html
+        expect(after).toContain('[Sub-agents')
+        expect(after).toContain('thing')
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+
+  it('5.4 — sub-agent JSONL appears BEFORE parent tool_use (reverse race adoption)', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit, coalesceMs: 20, minIntervalMs: 20, heartbeatMs: 0,
+      })
+      const stem = 'session-D'
+      const parent = join(projectsDir, `${stem}.jsonl`)
+      writeFileSync(parent, '')
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'race rev'))
+        // Create sub JSONL first with prompt; no parent tool_use yet
+        const sub = mkSubagentJsonl(projectsDir, stem, 'aidR')
+        appendFileSync(sub, subAgentUserLine('PROMPT-Y'))
+        await wait(200)
+        const orphanHtml = bot.edits[bot.edits.length - 1].html
+        expect(orphanHtml).toContain('(uncorrelated)')
+        // Now parent emits the Agent tool_use → adoption
+        appendFileSync(parent, parentAgentToolUseLine('toolu_p1', 'reverse race target', 'PROMPT-Y'))
+        await wait(200)
+        const adoptedHtml = bot.edits[bot.edits.length - 1].html
+        expect(adoptedHtml).toContain('reverse race target')
+        expect(adoptedHtml).not.toContain('(uncorrelated)')
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+
+  it('5.5 — sub-sub-agent renders only as (spawned N) suffix on parent', async () => {
+    await withFlag(async () => {
+      const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+      const bot = mockBot()
+      const driver = createProgressDriver({
+        emit: bot.emit, coalesceMs: 20, minIntervalMs: 20, heartbeatMs: 0,
+      })
+      const stem = 'session-E'
+      const parent = join(projectsDir, `${stem}.jsonl`)
+      writeFileSync(parent, '')
+      const tail = startSessionTail({
+        cwd, claudeHome, rescanIntervalMs: 20,
+        onEvent: (ev) => driver.ingest(ev, null),
+      })
+      try {
+        await wait(80)
+        appendFileSync(parent, enqueueLine('c1', 'nested'))
+        appendFileSync(parent, parentAgentToolUseLine('toolu_p1', 'parent sub', 'PROMPT-N'))
+        const subA = mkSubagentJsonl(projectsDir, stem, 'aidA')
+        appendFileSync(subA, subAgentUserLine('PROMPT-N'))
+        // Sub-agent A emits a nested Agent call (sub-sub-agent)
+        appendFileSync(
+          subA,
+          subAgentToolUseLine('toolu_inner', 'Agent', { description: 'inner', prompt: 'PROMPT-INNER' }),
+        )
+        await wait(250)
+        const html = bot.edits[bot.edits.length - 1].html
+        expect(html).toContain('parent sub')
+        expect(html).toContain('(spawned 1)')
+        // Sub-sub-agent must NOT appear as its own row
+        expect(html).not.toContain('inner')
+      } finally {
+        tail.stop()
+        driver.dispose?.()
+      }
+    })
+  }, 15_000)
+})

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -337,3 +337,182 @@ describe('progress-card render', () => {
     expect(diff.length).toBeLessThanOrEqual(2)
   })
 })
+
+// ─── Multi-agent correlation reducer tests ───────────────────────────────
+//
+// Renderer is unchanged in this PR, so we only assert state-shape — the
+// rendered HTML is verified by the renderer PR.
+
+describe('progress-card reducer — multi-agent correlation', () => {
+  it('forward race: parent Agent tool_use stages a pendingAgentSpawn', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'design ux', prompt: 'PROMPT-A', subagent_type: 'researcher' },
+      },
+    ])
+    expect(st.pendingAgentSpawns.size).toBe(1)
+    expect(st.pendingAgentSpawns.get('toolu_p1')?.promptText).toBe('PROMPT-A')
+    expect(st.subAgents.size).toBe(0)
+  })
+
+  it('forward race: sub_agent_started moves pending → subAgents and links checklist item', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'design ux', prompt: 'PROMPT-A' },
+      },
+      { kind: 'sub_agent_started', agentId: 'aaa', firstPromptText: 'PROMPT-A' },
+    ])
+    expect(st.pendingAgentSpawns.size).toBe(0)
+    expect(st.subAgents.size).toBe(1)
+    const sa = st.subAgents.get('aaa')!
+    expect(sa.parentToolUseId).toBe('toolu_p1')
+    expect(sa.description).toBe('design ux')
+    expect(sa.state).toBe('running')
+    // Checklist item linked
+    const agentItem = st.items.find((i) => i.toolUseId === 'toolu_p1')!
+    expect(agentItem.spawnedAgentId).toBe('aaa')
+  })
+
+  it('reverse race: sub_agent_started lands first as orphan, then parent adopts', () => {
+    const st = fold([
+      enqueue('go'),
+      { kind: 'sub_agent_started', agentId: 'bbb', firstPromptText: 'PROMPT-B' },
+    ])
+    expect(st.subAgents.get('bbb')?.parentToolUseId).toBeNull()
+    expect(st.subAgents.get('bbb')?.description).toBe('(uncorrelated)')
+    const st2 = reduce(
+      st,
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p2',
+        input: { description: 'audit', prompt: 'PROMPT-B' },
+      },
+      9999,
+    )
+    expect(st2.pendingAgentSpawns.size).toBe(0)
+    expect(st2.subAgents.get('bbb')?.parentToolUseId).toBe('toolu_p2')
+    expect(st2.subAgents.get('bbb')?.description).toBe('audit')
+  })
+
+  it('two parallel Agent calls with identical prompts: FIFO arrival order assigns', () => {
+    // Parent emits two Agent tool_uses with the SAME prompt text. Two
+    // sub-agent JSONLs appear in some order. Each sub_agent_started
+    // adopts the FIRST remaining pending spawn (FIFO).
+    let st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'first', prompt: 'DUP' },
+      },
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p2',
+        input: { description: 'second', prompt: 'DUP' },
+      },
+    ])
+    st = reduce(st, { kind: 'sub_agent_started', agentId: 'A', firstPromptText: 'DUP' }, 5000)
+    st = reduce(st, { kind: 'sub_agent_started', agentId: 'B', firstPromptText: 'DUP' }, 5100)
+    // Both correlated, deterministic FIFO
+    expect(st.subAgents.get('A')?.parentToolUseId).toBe('toolu_p1')
+    expect(st.subAgents.get('B')?.parentToolUseId).toBe('toolu_p2')
+    expect(st.pendingAgentSpawns.size).toBe(0)
+  })
+
+  it('sub_agent_tool_use increments toolCount and sets currentTool', () => {
+    let st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+    ])
+    st = reduce(
+      st,
+      { kind: 'sub_agent_tool_use', agentId: 'X', toolUseId: 'toolu_x1', toolName: 'Read', input: { file_path: '/f' } },
+      6000,
+    )
+    const sa = st.subAgents.get('X')!
+    expect(sa.toolCount).toBe(1)
+    expect(sa.currentTool?.tool).toBe('Read')
+    // Tool result clears currentTool
+    st = reduce(st, { kind: 'sub_agent_tool_result', agentId: 'X', toolUseId: 'toolu_x1' }, 6100)
+    expect(st.subAgents.get('X')!.currentTool).toBeUndefined()
+  })
+
+  it("parent's tool_result is authoritative: overrides early sub_agent_turn_end on isError", () => {
+    let st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+      { kind: 'sub_agent_turn_end', agentId: 'X' },
+    ])
+    expect(st.subAgents.get('X')?.state).toBe('done')
+    st = reduce(
+      st,
+      { kind: 'tool_result', toolUseId: 'toolu_p1', toolName: 'Agent', isError: true },
+      7000,
+    )
+    expect(st.subAgents.get('X')?.state).toBe('failed')
+  })
+
+  it('sub_agent_nested_spawn increments nestedSpawnCount but does not create a row', () => {
+    let st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'parent', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+    ])
+    st = reduce(st, { kind: 'sub_agent_nested_spawn', agentId: 'X' }, 8000)
+    st = reduce(st, { kind: 'sub_agent_nested_spawn', agentId: 'X' }, 8100)
+    expect(st.subAgents.get('X')?.nestedSpawnCount).toBe(2)
+    expect(st.subAgents.size).toBe(1) // no row for the nested ones
+  })
+
+  it('turn_end closes running sub-agents and clears pending spawns', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p2',
+        input: { description: 'd2', prompt: 'P2' },
+      },
+      // P2's sub-agent JSONL never appears
+      { kind: 'turn_end', durationMs: 1 },
+    ])
+    expect(st.subAgents.get('X')?.state).toBe('done')
+    expect(st.pendingAgentSpawns.size).toBe(0)
+    expect(st.stage).toBe('done')
+  })
+})

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -492,6 +492,142 @@ describe('progress-card reducer — multi-agent correlation', () => {
     expect(st.subAgents.size).toBe(1) // no row for the nested ones
   })
 
+  it('flag-off renderer ignores subAgents (byte-identical legacy output)', () => {
+    // Force flag off
+    const prev = process.env.PROGRESS_CARD_MULTI_AGENT
+    delete process.env.PROGRESS_CARD_MULTI_AGENT
+    try {
+      const st = fold([
+        enqueue('go'),
+        {
+          kind: 'tool_use',
+          toolName: 'Agent',
+          toolUseId: 'toolu_p1',
+          input: { description: 'd', prompt: 'P' },
+        },
+        { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+      ])
+      const html = render(st, 5000)
+      expect(html).not.toContain('[Main')
+      expect(html).not.toContain('[Sub-agents')
+      expect(html).toContain('Agent')
+    } finally {
+      if (prev != null) process.env.PROGRESS_CARD_MULTI_AGENT = prev
+    }
+  })
+
+  it('flag-on renderer adds [Main]/[Sub-agents] sections with chrono ordering and subagent_type', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      let st = fold([
+        enqueue('go'),
+        {
+          kind: 'tool_use',
+          toolName: 'Agent',
+          toolUseId: 'toolu_p1',
+          input: { description: 'design ux', prompt: 'P1', subagent_type: 'researcher' },
+        },
+        {
+          kind: 'tool_use',
+          toolName: 'Agent',
+          toolUseId: 'toolu_p2',
+          input: { description: 'audit', prompt: 'P2', subagent_type: 'worker' },
+        },
+      ])
+      // Sub-agents land in REVERSE chronological order to test sort
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'B', firstPromptText: 'P2' }, 5000)
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'A', firstPromptText: 'P1' }, 5100)
+      const html = render(st, 6000)
+      expect(html).toContain('[Main · 2 tools]')
+      expect(html).toContain('[Sub-agents · 2 running]')
+      expect(html).toContain('design ux')
+      expect(html).toContain('audit')
+      expect(html).toContain('researcher')
+      expect(html).toContain('worker')
+      // Chrono order: B started first (5000) so it should appear before A (5100)
+      const idxB = html.indexOf('audit')
+      const idxA = html.indexOf('design ux')
+      // 'design ux' also appears in [Main]; find inside [Sub-agents]
+      const subSection = html.slice(html.indexOf('[Sub-agents'))
+      const subB = subSection.indexOf('audit')
+      const subA = subSection.indexOf('design ux')
+      expect(subB).toBeLessThan(subA)
+      void idxA; void idxB
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+
+  it('flag-on: nested spawn renders (spawned N) suffix; running Agent line stays 🤖 until tool_result', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      let st = fold([
+        enqueue('go'),
+        {
+          kind: 'tool_use',
+          toolName: 'Agent',
+          toolUseId: 'toolu_p1',
+          input: { description: 'parent task', prompt: 'P' },
+        },
+        { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+      ])
+      st = reduce(st, { kind: 'sub_agent_nested_spawn', agentId: 'X' }, 6000)
+      st = reduce(st, { kind: 'sub_agent_nested_spawn', agentId: 'X' }, 6100)
+      st = reduce(
+        st,
+        { kind: 'sub_agent_tool_use', agentId: 'X', toolUseId: 't1', toolName: 'Read', input: { file_path: '/f' } },
+        6200,
+      )
+      const html = render(st, 7000)
+      expect(html).toContain('(spawned 2)')
+      // Main agent line uses 🤖 not ✅ while running
+      const mainSection = html.split('[Sub-agents')[0]
+      expect(mainSection).toContain('🤖')
+      expect(mainSection).not.toContain('✅ Agent')
+      // Sub-agent activity line shows the current tool
+      expect(html).toContain('└ 🔧')
+      expect(html).toContain('Read')
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+
+  it('flag-on turn_end: sub-agents collapse to one-line summary, [Main] Agent flips to ✅', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      let st = fold([
+        enqueue('go'),
+        {
+          kind: 'tool_use',
+          toolName: 'Agent',
+          toolUseId: 'toolu_p1',
+          input: { description: 'task A', prompt: 'P' },
+        },
+        { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+        {
+          kind: 'sub_agent_tool_use',
+          agentId: 'X',
+          toolUseId: 't1',
+          toolName: 'Read',
+          input: { file_path: '/a' },
+        },
+        { kind: 'sub_agent_tool_result', agentId: 'X', toolUseId: 't1' },
+      ])
+      st = reduce(st, { kind: 'tool_result', toolUseId: 'toolu_p1', toolName: 'Agent' }, 7000)
+      st = reduce(st, { kind: 'turn_end', durationMs: 1 }, 7500)
+      const html = render(st, 8000)
+      expect(html).toContain('✅')
+      expect(html).toContain('task A')
+      // Collapsed form contains "· N tools"
+      expect(html).toMatch(/✅ task A.*· 1 tools/)
+      // No two-line `└` activity in the collapsed form
+      const subSection = html.split('[Sub-agents')[1] ?? ''
+      expect(subSection).not.toContain('└ 🔧')
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+
   it('turn_end closes running sub-agents and clears pending spawns', () => {
     const st = fold([
       enqueue('go'),

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -368,7 +368,7 @@ describe('projectSubagentLine', () => {
     ])
   })
 
-  it('emits sub_agent_tool_use for assistant tool_use blocks; nested Agent fires nested_spawn too', () => {
+  it('emits sub_agent_tool_use for regular tools; nested Agent fires ONLY nested_spawn', () => {
     const st = { hasEmittedStart: true }
     const line = JSON.stringify({
       type: 'assistant',
@@ -380,10 +380,14 @@ describe('projectSubagentLine', () => {
       },
     })
     const events = projectSubagentLine(line, 'X', st)
-    expect(events.length).toBe(3)
+    // 2 events: 1 sub_agent_tool_use (Read) + 1 nested_spawn (the Agent).
+    // Per design §5.5 we do NOT also emit sub_agent_tool_use for the
+    // nested Agent — that would surface the sub-sub-agent's description
+    // as the parent sub-agent's currentTool and break "no recursion in
+    // rendering."
+    expect(events.length).toBe(2)
     expect(events[0].kind).toBe('sub_agent_tool_use')
-    expect(events[1].kind).toBe('sub_agent_tool_use')
-    expect(events[2]).toEqual({ kind: 'sub_agent_nested_spawn', agentId: 'X' })
+    expect(events[1]).toEqual({ kind: 'sub_agent_nested_spawn', agentId: 'X' })
   })
 
   it('emits sub_agent_turn_end on system turn_duration', () => {

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   projectTranscriptLine,
+  projectSubagentLine,
   sanitizeCwdToProjectName,
   getProjectsDirForCwd,
   startSessionTail,
@@ -337,5 +338,68 @@ describe('startSessionTail — re-attach resumes from saved cursor', () => {
     } finally {
       handle.stop()
     }
+  })
+})
+
+describe('projectSubagentLine', () => {
+  it('emits sub_agent_started exactly once for the first user message (string content)', () => {
+    const st = { hasEmittedStart: false }
+    const line = JSON.stringify({
+      isSidechain: true,
+      agentId: 'aaa',
+      type: 'user',
+      message: { role: 'user', content: 'hello sub-agent' },
+    })
+    const events = projectSubagentLine(line, 'aaa', st)
+    expect(events).toEqual([
+      { kind: 'sub_agent_started', agentId: 'aaa', firstPromptText: 'hello sub-agent' },
+    ])
+    expect(st.hasEmittedStart).toBe(true)
+    // Second user message → tool_results, NOT another sub_agent_started
+    const line2 = JSON.stringify({
+      type: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'toolu_x', is_error: false }],
+      },
+    })
+    const events2 = projectSubagentLine(line2, 'aaa', st)
+    expect(events2).toEqual([
+      { kind: 'sub_agent_tool_result', agentId: 'aaa', toolUseId: 'toolu_x', isError: undefined },
+    ])
+  })
+
+  it('emits sub_agent_tool_use for assistant tool_use blocks; nested Agent fires nested_spawn too', () => {
+    const st = { hasEmittedStart: true }
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } },
+          { type: 'tool_use', id: 'toolu_b', name: 'Agent', input: { description: 'nested', prompt: 'nested-p' } },
+        ],
+      },
+    })
+    const events = projectSubagentLine(line, 'X', st)
+    expect(events.length).toBe(3)
+    expect(events[0].kind).toBe('sub_agent_tool_use')
+    expect(events[1].kind).toBe('sub_agent_tool_use')
+    expect(events[2]).toEqual({ kind: 'sub_agent_nested_spawn', agentId: 'X' })
+  })
+
+  it('emits sub_agent_turn_end on system turn_duration', () => {
+    const st = { hasEmittedStart: true }
+    const events = projectSubagentLine(
+      JSON.stringify({ type: 'system', subtype: 'turn_duration', durationMs: 42 }),
+      'X',
+      st,
+    )
+    expect(events).toEqual([{ kind: 'sub_agent_turn_end', agentId: 'X' }])
+  })
+
+  it('skips malformed lines silently', () => {
+    const st = { hasEmittedStart: false }
+    expect(projectSubagentLine('{not-json', 'X', st)).toEqual([])
+    expect(projectSubagentLine('{}', 'X', st)).toEqual([])
+    expect(st.hasEmittedStart).toBe(false)
   })
 })


### PR DESCRIPTION
Rescue PR. PRs #29 and #31 were auto-closed when their stacked base branches (phase/multi-agent-foundation, phase/multi-agent-renderer) were deleted during the merge of #28 and #30. The underlying commits survived on branches. This PR consolidates the 4 remaining layers (correlation + renderer + rate-limit + harness) cherry-picked onto current main on top of merged #28.

## What's inside
- multi-agent correlation (subagent JSONL watcher + reducer)
- multi-agent renderer (two-section [Main]/[Sub-agents] card)
- multi-agent edit-budget guardrail
- multi-agent integration test harness scenarios §5.1-§5.5

## Verification
- 538 tests pass, tsc clean
- Feature flag `PROGRESS_CARD_MULTI_AGENT=1` — off = byte-identical to today's behaviour

See original per-PR descriptions on closed #29/#31 + merged #30/#32 for full rationale.