### PR TITLE
fix(telegram-plugin): progress card pinned to stale messageId across turns

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -305,9 +305,21 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         threadId = event.threadId ?? undefined
         // Remember the active chat so subsequent events in this turn
         // (routed from the session-tail with chatIdMaybe=null) still
-        // find their way here.
-        currentChatId = chatId
-        currentThreadId = threadId
+        // find their way here. Guard against orphan enqueues whose
+        // content lacks the <channel chat_id="…"> wrapper — those
+        // surface as { chatId: null }, and overwriting currentChatId
+        // with null here would lose the prior turn's routing and cause
+        // every subsequent tool_use / turn_end in this driver to fall
+        // out at the chatId==null guard below. Fall back to the prior
+        // turn's chat instead, mirroring how the session-tail itself
+        // continues to deliver events.
+        if (chatId != null) {
+          currentChatId = chatId
+          currentThreadId = threadId
+        } else {
+          chatId = currentChatId
+          threadId = currentThreadId
+        }
       } else if (chatId == null) {
         // Non-enqueue event with no explicit chat: fall back to the
         // most recently enqueued chat for this driver.
@@ -371,10 +383,18 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           chats.delete(k)
           lastHeartbeatBucket.delete(k)
           editTimestamps.delete(k)
-          if (currentChatId === chatId && currentThreadId === threadId) {
-            currentChatId = null
-            currentThreadId = undefined
-          }
+          // Intentionally DO NOT null currentChatId / currentThreadId
+          // here. Doing so used to break the next turn whenever its
+          // enqueue arrived as an orphan (no <channel> wrapper):
+          // ingest() would lose its chatId fallback at line ~317 and
+          // every subsequent tool_use / turn_end for that turn would
+          // bail, which in turn meant handleStreamReply never received
+          // a done:true for the previous turn — leaving the stale
+          // progress-card stream pinned in activeDraftStreams and the
+          // next turn editing the prior turn's messageId. Keeping the
+          // last-active routing across turn_end is harmless: the next
+          // wrapped enqueue will overwrite it; an orphan enqueue will
+          // correctly inherit it.
           // Stop heartbeat when no chats remain active.
           if (chats.size === 0) stopHeartbeat()
         }

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -3361,6 +3361,20 @@ async function handleInbound(
   // steering message extended an already-live turn, skip — the existing
   // card keeps updating for the in-flight turn.
   if (!isSteering) {
+    // Defense-in-depth (fix B): close any progress-lane stream still
+    // sitting in `activeDraftStreams` for this chat+thread BEFORE the
+    // driver fires its skeleton render. The normal lifecycle relies on
+    // either (a) the previous turn's `turn_end` calling closeProgressLane
+    // via handleSessionEvent, or (b) the driver's own done:true emit
+    // causing handleStreamReply to delete the entry on finalize. Both
+    // paths can be skipped under pathological session JSONL (orphan
+    // enqueues with no <channel> wrapper, dropped turn_end events). When
+    // either skip happens, the next startTurn would otherwise reuse the
+    // stale stream and edit the previous turn's messageId — burying the
+    // card far up-chat above newer user messages. Proactively closing
+    // the lane at the true "new user turn" boundary is the only event
+    // both paths reliably converge on.
+    closeProgressLane(chat_id, messageThreadId)
     try {
       progressDriver?.startTurn({
         chatId: chat_id,

--- a/telegram-plugin/tests/progress-card-harness.test.ts
+++ b/telegram-plugin/tests/progress-card-harness.test.ts
@@ -31,6 +31,9 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { startSessionTail, getProjectsDirForCwd, type SessionEvent } from '../session-tail.js'
 import { createProgressDriver } from '../progress-card-driver.js'
+import { handleStreamReply } from '../stream-reply-handler.js'
+import type { DraftStreamHandle } from '../draft-stream.js'
+import { createMockBot, microtaskFlush } from './bot-api.harness.js'
 
 // ─── Mock Telegram Bot API ────────────────────────────────────────────────
 
@@ -661,5 +664,182 @@ describe('progress-card multi-agent harness', () => {
         driver.dispose?.()
       }
     })
+  }, 15_000)
+})
+
+// ─── Regression: progress card pinned to stale messageId across turns ────
+//
+// Two production bugs cause every progress-card update to land on the same
+// Telegram messageId across many consecutive turns, so the card gets
+// buried far up-chat above newer user messages and appears invisible:
+//
+//   (A) Orphan-turn routing: enqueue events occasionally land WITHOUT the
+//       <channel chat_id="…"> wrapper. The driver's enqueue handler then
+//       has no chatId and bails. Without a fallback the subsequent
+//       turn_end can't route either, so done:true is never emitted.
+//
+//   (B) Stale stream persistence: when the driver's done:true never
+//       emits, handleStreamReply never deletes the activeDraftStreams
+//       entry and the next turn's startTurn reuses the existing stream
+//       — editing the prior message rather than spawning a new one.
+//
+// This block wires the driver to the REAL handleStreamReply against a
+// mock bot.api so we observe the same `editMessageText`/`sendMessage`
+// pattern Telegram would receive in production.
+
+describe('progress-card cross-turn lifecycle (regression for stale messageId)', () => {
+  it('three consecutive turns each spawn a fresh messageId, even with one orphan enqueue', async () => {
+    const bot = createMockBot(800)
+    const activeDraftStreams = new Map<string, DraftStreamHandle>()
+    const activeDraftParseModes = new Map<string, 'HTML' | 'MarkdownV2' | undefined>()
+
+    const driver = createProgressDriver({
+      // Wire the driver's emit through the same handleStreamReply path
+      // server.ts uses, against the mock bot.
+      emit: ({ chatId, threadId, html, done }) => {
+        void handleStreamReply(
+          {
+            chat_id: chatId,
+            text: html,
+            done,
+            message_thread_id: threadId,
+            lane: 'progress',
+            format: 'html',
+          },
+          { activeDraftStreams, activeDraftParseModes },
+          {
+            bot,
+            markdownToHtml: (t) => t,
+            escapeMarkdownV2: (t) => t,
+            repairEscapedWhitespace: (t) => t,
+            takeHandoffPrefix: () => '',
+            assertAllowedChat: () => {},
+            resolveThreadId: (_, explicit) => (explicit != null ? Number(explicit) : undefined),
+            disableLinkPreview: true,
+            defaultFormat: 'html',
+            logStreamingEvent: () => {},
+            endStatusReaction: () => {},
+            historyEnabled: false,
+            recordOutbound: () => {},
+            writeError: () => {},
+            // Fast throttle so the test runs quickly without burning
+            // wall-clock waits.
+            throttleMs: 10,
+          },
+        ).catch(() => { /* swallow — same fire-and-forget posture as server.ts */ })
+      },
+      coalesceMs: 5,
+      minIntervalMs: 5,
+      heartbeatMs: 0,
+    })
+
+    const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+    // Helper that mirrors server.ts's onEvent fan-out for handleSessionEvent
+    // → progressDriver.ingest. We don't need the full handleSessionEvent;
+    // we only need to feed events into the driver. The closeProgressLane
+    // path is what we want to exercise WITHOUT.
+    const ingest = (ev: SessionEvent) => driver.ingest(ev, null)
+
+    // ─── Turn 1 — wrapped enqueue (normal) ─────────────────────────────
+    driver.startTurn({ chatId: 'c1', userText: 'first turn' })
+    ingest({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1', input: {} } as SessionEvent)
+    await wait(40)
+    ingest({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' } as SessionEvent)
+    ingest({ kind: 'turn_end', durationMs: 100 } as SessionEvent)
+    await microtaskFlush(20)
+    await wait(50)
+    await microtaskFlush(20)
+
+    // ─── Turn 2 — ORPHAN enqueue (no channel wrapper) ──────────────────
+    // This simulates the production case where the parent JSONL writes a
+    // queue-operation enqueue whose `content` lacks the <channel> XML.
+    // The session-tail surfaces it as { kind:'enqueue', chatId:null, … }.
+    // No startTurn call here either — startTurn comes from the inbound
+    // user message gate, which the orphan path bypasses entirely (the
+    // model self-enqueued, e.g. via auto-resume or an internal trigger).
+    ingest({
+      kind: 'enqueue',
+      chatId: null,
+      messageId: null,
+      threadId: null,
+      rawContent: 'orphan content with no channel wrapper',
+    } as SessionEvent)
+    ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 't2', input: {} } as SessionEvent)
+    await wait(40)
+    ingest({ kind: 'tool_result', toolUseId: 't2', toolName: 'Read' } as SessionEvent)
+    ingest({ kind: 'turn_end', durationMs: 100 } as SessionEvent)
+    await microtaskFlush(20)
+    await wait(50)
+    await microtaskFlush(20)
+
+    // ─── Turn 3 — wrapped enqueue (normal) ─────────────────────────────
+    driver.startTurn({ chatId: 'c1', userText: 'third turn' })
+    ingest({ kind: 'tool_use', toolName: 'Grep', toolUseId: 't3', input: {} } as SessionEvent)
+    await wait(40)
+    ingest({ kind: 'tool_result', toolUseId: 't3', toolName: 'Grep' } as SessionEvent)
+    ingest({ kind: 'turn_end', durationMs: 100 } as SessionEvent)
+    await microtaskFlush(20)
+    await wait(50)
+    await microtaskFlush(20)
+
+    driver.dispose?.()
+
+    // ─── Assertions ────────────────────────────────────────────────────
+
+    // (1) Each turn must have spawned its OWN sendMessage (a new
+    //     Telegram message_id). With three turns we expect at least three
+    //     distinct sendMessage calls — one per turn's first emit. Edits
+    //     to a turn's own message via editMessageText are fine; what's
+    //     not OK is the next turn editing the prior turn's message.
+    const sentMessageIds = bot.api.sendMessage.mock.results
+      .map((r) => (r.value as Promise<{ message_id: number }>))
+    const resolvedIds = await Promise.all(sentMessageIds)
+    const distinctSendIds = new Set(resolvedIds.map((r) => r.message_id))
+    expect(distinctSendIds.size).toBeGreaterThanOrEqual(3)
+
+    // (2) Every editMessageText call must target a message_id that was
+    //     produced by a sendMessage WITHIN THE SAME TURN. We check this
+    //     by walking the call log in order: track the "current" sent
+    //     id (the most recent sendMessage), and assert every edit
+    //     between sends targets that id. Cross-turn edits would target
+    //     an id from a previous turn, which is the bug.
+    const calls: Array<{ kind: 'send' | 'edit'; id: number }> = []
+    for (const call of bot.api.sendMessage.mock.results) {
+      const v = await (call.value as Promise<{ message_id: number }>)
+      calls.push({ kind: 'send', id: v.message_id })
+    }
+    // Re-derive call ordering from invocation order. mock.invocationCallOrder
+    // gives a global ordering across mocks, letting us interleave them.
+    const sendOrder = bot.api.sendMessage.mock.invocationCallOrder
+    const editOrder = bot.api.editMessageText.mock.invocationCallOrder
+    const ordered: Array<{ kind: 'send' | 'edit'; id?: number; idx: number }> = []
+    sendOrder.forEach((seq, i) => ordered.push({ kind: 'send', idx: seq, id: undefined }))
+    editOrder.forEach((seq, i) =>
+      ordered.push({ kind: 'edit', idx: seq, id: bot.api.editMessageText.mock.calls[i][1] as number }),
+    )
+    ordered.sort((a, b) => a.idx - b.idx)
+
+    // Replay the chronologically-ordered stream of API calls.
+    let currentSendId: number | null = null
+    let sendIndex = 0
+    for (const c of ordered) {
+      if (c.kind === 'send') {
+        const r = await (bot.api.sendMessage.mock.results[sendIndex++].value as Promise<{ message_id: number }>)
+        currentSendId = r.message_id
+      } else {
+        // An edit must target the most recently sent id (same turn).
+        expect(c.id).toBe(currentSendId)
+      }
+    }
+
+    // (3) Every turn (including the orphan one in the middle) must have
+    //     emitted a done:true to the bot — i.e. handleStreamReply with
+    //     done=true ran for each turn, deleting the stream entry. We
+    //     observe this indirectly: activeDraftStreams must be empty at
+    //     the end, AND total sendMessage calls is one per turn (since
+    //     done:true clean-up means each turn's first emit creates a
+    //     fresh stream).
+    expect(activeDraftStreams.size).toBe(0)
   }, 15_000)
 })

--- a/telegram-plugin/tests/progress-card-harness.test.ts
+++ b/telegram-plugin/tests/progress-card-harness.test.ts
@@ -747,9 +747,9 @@ describe('progress-card cross-turn lifecycle (regression for stale messageId)', 
     await wait(40)
     ingest({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' } as SessionEvent)
     ingest({ kind: 'turn_end', durationMs: 100 } as SessionEvent)
-    await microtaskFlush(20)
-    await wait(50)
-    await microtaskFlush(20)
+    await microtaskFlush(50)
+    await wait(400)
+    await microtaskFlush(50)
 
     // ─── Turn 2 — ORPHAN enqueue (no channel wrapper) ──────────────────
     // This simulates the production case where the parent JSONL writes a
@@ -769,9 +769,9 @@ describe('progress-card cross-turn lifecycle (regression for stale messageId)', 
     await wait(40)
     ingest({ kind: 'tool_result', toolUseId: 't2', toolName: 'Read' } as SessionEvent)
     ingest({ kind: 'turn_end', durationMs: 100 } as SessionEvent)
-    await microtaskFlush(20)
-    await wait(50)
-    await microtaskFlush(20)
+    await microtaskFlush(50)
+    await wait(400)
+    await microtaskFlush(50)
 
     // ─── Turn 3 — wrapped enqueue (normal) ─────────────────────────────
     driver.startTurn({ chatId: 'c1', userText: 'third turn' })
@@ -779,9 +779,9 @@ describe('progress-card cross-turn lifecycle (regression for stale messageId)', 
     await wait(40)
     ingest({ kind: 'tool_result', toolUseId: 't3', toolName: 'Grep' } as SessionEvent)
     ingest({ kind: 'turn_end', durationMs: 100 } as SessionEvent)
-    await microtaskFlush(20)
-    await wait(50)
-    await microtaskFlush(20)
+    await microtaskFlush(50)
+    await wait(400)
+    await microtaskFlush(50)
 
     driver.dispose?.()
 


### PR DESCRIPTION
## Summary

The live progress card was buried far up-chat above newer user messages because every update across 10+ consecutive turns landed on the same Telegram `messageId` (e.g. 852). Only the final `done=true` of the very last turn spawned a fresh message at the bottom — which the user observed as "only the final reply arrives."

Two adjacent root causes:

- **Fix A — `progress-card-driver.ts`**: the driver nulled `currentChatId` / `currentThreadId` on `turn_end`, AND an orphan enqueue (one whose `content` lacks the `<channel chat_id="…">` wrapper — observed in 6 of 22 enqueues in `e1701783.jsonl`) overwrote `currentChatId` with `null` in the enqueue branch. Either step erased the routing fallback for subsequent `tool_use` / `turn_end` events, so the driver never emitted `done:true` for the orphan turn — leaving handleStreamReply with no chance to delete the stale `activeDraftStreams` entry.
- **Fix B — `server.ts`**: even with Fix A, two cleanup paths (`handleSessionEvent('turn_end')` → `closeProgressLane`, and the driver's own `done:true` emit → handleStreamReply finalize+delete) can both be skipped under pathological JSONL. Proactively close the progress lane at the inbound-message boundary, which is the only event both paths reliably converge on. New user message → new card.

Diagnosed via a new failing integration test in `progress-card-harness.test.ts` that wires the driver to the real `handleStreamReply` against a mock bot.api and runs three consecutive turns with a middle orphan turn. Pre-fix: 1 distinct `sendMessage` across all 3 turns, all `editMessageText` calls targeting the same id. Post-fix: 3 distinct sends, edits scoped per turn.

## Test plan

- [x] New regression test in `telegram-plugin/tests/progress-card-harness.test.ts` ("three consecutive turns each spawn a fresh messageId, even with one orphan enqueue") — fails on `main`, passes after Fix A.
- [x] Existing harness scenarios (5.1–5.5 multi-agent, sub-agent JSONL, heartbeat) all still pass.
- [x] Full plugin suite — 539/539 pass via `cd telegram-plugin && bun test`.
- [x] Top-level suite — 914/914 vitest + 26/26 bun via `bun run test`.
- [ ] Manual verification on the assistant agent: send 5 quick messages in a row and confirm each turn's progress card lands as a fresh Telegram message bottom-of-chat (not an edit of the previous turn's card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)